### PR TITLE
Add signature border and caption to PDF footer

### DIFF
--- a/app/services/pdf_generator_service/configuration.rb
+++ b/app/services/pdf_generator_service/configuration.rb
@@ -76,9 +76,10 @@ class PdfGeneratorService
     DISCLAIMER_TEXT_SIZE = ASSESSMENT_FIELD_TEXT_SIZE  # Match assessment field text
     DISCLAIMER_TEXT_LINES = 3  # Height in lines of text for disclaimer
     SIGNATURE_HEIGHT_LINES = 4  # Maximum height in lines of text
+    SIGNATURE_CAPTION_LINES = 1.5  # Space for caption below signature
     TEXT_LINE_HEIGHT = DISCLAIMER_TEXT_SIZE * 1.5  # Standard line height multiplier
     DISCLAIMER_TEXT_HEIGHT = DISCLAIMER_TEXT_LINES * TEXT_LINE_HEIGHT  # Total disclaimer text height
-    SIGNATURE_HEIGHT = SIGNATURE_HEIGHT_LINES * TEXT_LINE_HEIGHT  # Total signature height
+    SIGNATURE_HEIGHT = (SIGNATURE_HEIGHT_LINES + SIGNATURE_CAPTION_LINES) * TEXT_LINE_HEIGHT  # Total signature height including caption
     FOOTER_INTERNAL_PADDING = 10  # Padding between elements within footer
     FOOTER_VERTICAL_PADDING = 15  # Bottom padding for footer
     FOOTER_TOP_PADDING = 30  # Top padding for footer (about 2 lines)

--- a/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
+++ b/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
@@ -88,10 +88,35 @@ class PdfGeneratorService
         # Since we want them vertically aligned, position from same top y
         y_position = content_top_y
 
+        # Add border around signature
+        border_padding = 2
+        border_x = x_position - border_padding
+        border_y = y_position + border_padding
+        border_width = width + (border_padding * 2)
+        border_height = height + (border_padding * 2)
+
+        # Draw border
+        pdf.stroke_color "CCCCCC"
+        pdf.line_width = 1
+        pdf.stroke_rectangle [border_x, border_y], border_width, border_height
+
         # Render the signature
         ImageProcessor.render_processed_image(
           pdf, image, x_position, y_position, width, height, signature_attachment
         )
+
+        # Add caption below signature
+        caption_y = y_position - height - 10
+        pdf.text_box I18n.t("pdf.signature.caption"),
+          at: [border_x, caption_y],
+          width: border_width,
+          height: 20,
+          size: DISCLAIMER_TEXT_SIZE,
+          align: :center,
+          valign: :top
+
+        # Reset stroke color to default
+        pdf.stroke_color "000000"
       rescue => e
         Rails.logger.error "Failed to render signature: #{e.message}"
       end

--- a/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
+++ b/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
@@ -83,7 +83,7 @@ class PdfGeneratorService
 
         # Add border around signature with more padding
         border_padding = 5
-        
+
         # Position signature aligned with disclaimer text
         # Shift left to account for border and padding so the border aligns to the right edge
         x_position = x_offset + available_width - width - (border_padding * 2)
@@ -96,9 +96,9 @@ class PdfGeneratorService
         border_y = y_position + border_padding
         border_width = width + (border_padding * 2)
         border_height = height + (border_padding * 2)
-        
+
         # Adjust signature position to be inside the border
-        x_position = x_position + border_padding
+        x_position += border_padding
         y_position = y_position
 
         # Draw border

--- a/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
+++ b/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
@@ -81,19 +81,25 @@ class PdfGeneratorService
         signature_dimensions = calculate_signature_dimensions(image, available_width)
         width, height = signature_dimensions
 
+        # Add border around signature with more padding
+        border_padding = 5
+        
         # Position signature aligned with disclaimer text
-        # x_position is offset from left + remaining space to align right
-        x_position = x_offset + available_width - width
+        # Shift left to account for border and padding so the border aligns to the right edge
+        x_position = x_offset + available_width - width - (border_padding * 2)
         # y_position aligns with the disclaimer text area
         # Since we want them vertically aligned, position from same top y
         y_position = content_top_y
 
-        # Add border around signature
-        border_padding = 2
-        border_x = x_position - border_padding
+        # Calculate border position (signature is already shifted, so border starts at x_position)
+        border_x = x_position
         border_y = y_position + border_padding
         border_width = width + (border_padding * 2)
         border_height = height + (border_padding * 2)
+        
+        # Adjust signature position to be inside the border
+        x_position = x_position + border_padding
+        y_position = y_position
 
         # Draw border
         pdf.stroke_color "CCCCCC"
@@ -105,8 +111,8 @@ class PdfGeneratorService
           pdf, image, x_position, y_position, width, height, signature_attachment
         )
 
-        # Add caption below signature
-        caption_y = y_position - height - 10
+        # Add caption below signature (align with border)
+        caption_y = y_position - height - border_padding - 8
         pdf.text_box I18n.t("pdf.signature.caption"),
           at: [border_x, caption_y],
           width: border_width,
@@ -124,10 +130,12 @@ class PdfGeneratorService
 
     def self.calculate_signature_dimensions(image, max_width)
       # Use existing fit_dimensions method from PositionCalculator
+      # Account for border padding (5px on each side = 10px total)
+      border_total_padding = 10
       PositionCalculator.fit_dimensions(
         image.width,
         image.height,
-        max_width - FOOTER_INTERNAL_PADDING,  # Leave some padding
+        max_width - FOOTER_INTERNAL_PADDING - border_total_padding,  # Leave padding for border
         SIGNATURE_HEIGHT
       )
     end

--- a/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
+++ b/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
@@ -112,7 +112,7 @@ class PdfGeneratorService
         )
 
         # Add caption below signature (align with border)
-        caption_y = y_position - height - border_padding - 8
+        caption_y = y_position - height - border_padding - 4
         pdf.text_box I18n.t("pdf.signature.caption"),
           at: [border_x, caption_y],
           width: border_width,

--- a/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
+++ b/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
@@ -99,7 +99,6 @@ class PdfGeneratorService
 
         # Adjust signature position to be inside the border
         x_position += border_padding
-        y_position = y_position
 
         # Draw border
         pdf.stroke_color "CCCCCC"

--- a/config/locales/pdf.en.yml
+++ b/config/locales/pdf.en.yml
@@ -43,6 +43,9 @@ en:
       header: "Disclaimer"
       text: "This inspection report has been prepared in accordance with industry standards and guidelines. The findings and recommendations contained herein are based on the inspection conducted on the date specified. Any subsequent modifications, damage, or deterioration may not be reflected in this report."
 
+    signature:
+      caption: "Signature of Inspector"
+
     unit:
       details: "Unit Details"
       inspection_history: "Inspection History"


### PR DESCRIPTION
## Summary
- Adds a border around the signature image in the PDF footer
- Includes a caption "Signature of Inspector" below the signature
- Adjusts PDF layout to accommodate the signature caption height

## Changes

### PDF Generator Service
- **Configuration**: Introduced `SIGNATURE_CAPTION_LINES` to reserve space for the caption below the signature
- **DisclaimerFooterRenderer**:
  - Draws a light gray border around the signature image
  - Renders a centered caption below the signature using localized text
  - Resets stroke color after drawing the border

### Localization
- Added `signature.caption` key with value "Signature of Inspector" to `pdf.en.yml`

## Test plan
- Verify the signature in generated PDFs has a visible border
- Confirm the caption "Signature of Inspector" appears below the signature
- Check that the footer layout remains consistent and no overlapping occurs
- Ensure no errors are logged during PDF generation with signature rendering

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6fc7acab-80d1-4735-9244-dc70506a273a