### PR TITLE
Move QR code to top left corner in PDF headers

### DIFF
--- a/app/services/pdf_generator_service.rb
+++ b/app/services/pdf_generator_service.rb
@@ -40,9 +40,6 @@ class PdfGeneratorService
       # Disclaimer footer (only on first page)
       DisclaimerFooterRenderer.render_disclaimer_footer(pdf, inspection.user)
 
-      # QR Code in bottom right corner
-      ImageProcessor.generate_qr_code_footer(pdf, inspection)
-
       # Add DRAFT watermark overlay for draft inspections (except in test env)
       if !inspection.complete? && !Rails.env.test?
         Utilities.add_draft_watermark(pdf)
@@ -77,8 +74,6 @@ class PdfGeneratorService
 
       # Disclaimer footer (only on first page)
       DisclaimerFooterRenderer.render_disclaimer_footer(pdf, unit.user)
-
-      ImageProcessor.generate_qr_code_footer(pdf, unit)
 
       # Add debug info page if enabled (admins only)
       if debug_enabled && debug_queries.present?

--- a/app/services/pdf_generator_service/configuration.rb
+++ b/app/services/pdf_generator_service/configuration.rb
@@ -49,8 +49,9 @@ class PdfGeneratorService
     ASSESSMENT_BLOCK_SPACING = 8
 
     # QR Code constants
-    QR_CODE_SIZE = 80
-    QR_CODE_MARGIN = 0  # No margin - align with table right edge
+    # QR code size is 3 lines of header text (12pt * 1.5 line height * 3 lines)
+    QR_CODE_SIZE = (HEADER_TEXT_SIZE * 1.5 * 3).round
+    QR_CODE_MARGIN = 0  # No margin - align with page edge
     QR_CODE_BOTTOM_OFFSET = HEADER_SPACING  # Match header spacing from top
 
     # Unit photo constants

--- a/app/services/pdf_generator_service/header_generator.rb
+++ b/app/services/pdf_generator_service/header_generator.rb
@@ -4,6 +4,8 @@ class PdfGeneratorService
 
     def self.generate_inspection_pdf_header(pdf, inspection)
       create_inspection_header(pdf, inspection)
+      # Generate QR code in top left corner
+      ImageProcessor.generate_qr_code_header(pdf, inspection)
     end
 
     def self.create_inspection_header(pdf, inspection)
@@ -21,6 +23,8 @@ class PdfGeneratorService
 
     def self.generate_unit_pdf_header(pdf, unit)
       create_unit_header(pdf, unit)
+      # Generate QR code in top left corner
+      ImageProcessor.generate_qr_code_header(pdf, unit)
     end
 
     def self.create_unit_header(pdf, unit)
@@ -79,8 +83,10 @@ class PdfGeneratorService
 
       def render_inspection_text_section(pdf, inspection, report_id_text,
         status_text, status_color, logo_width)
-        width = pdf.bounds.width - logo_width
-        pdf.bounding_box([0, pdf.bounds.top], width: width) do
+        # Shift text to the right to accommodate QR code
+        qr_offset = Configuration::QR_CODE_SIZE + Configuration::HEADER_SPACING
+        width = pdf.bounds.width - logo_width - qr_offset
+        pdf.bounding_box([qr_offset, pdf.bounds.top], width: width) do
           pdf.text report_id_text, size: Configuration::HEADER_TEXT_SIZE,
             style: :bold
           pdf.text status_text, size: Configuration::HEADER_TEXT_SIZE,
@@ -95,8 +101,10 @@ class PdfGeneratorService
       end
 
       def render_unit_text_section(pdf, unit, unit_id_text, logo_width)
-        width = pdf.bounds.width - logo_width
-        pdf.bounding_box([0, pdf.bounds.top], width: width) do
+        # Shift text to the right to accommodate QR code
+        qr_offset = Configuration::QR_CODE_SIZE + Configuration::HEADER_SPACING
+        width = pdf.bounds.width - logo_width - qr_offset
+        pdf.bounding_box([qr_offset, pdf.bounds.top], width: width) do
           pdf.text unit_id_text, size: Configuration::HEADER_TEXT_SIZE,
             style: :bold
 

--- a/app/services/pdf_generator_service/image_processor.rb
+++ b/app/services/pdf_generator_service/image_processor.rb
@@ -7,6 +7,19 @@ class PdfGeneratorService
       render_qr_code_with_photo(pdf, entity, qr_code_png)
     end
 
+    def self.generate_qr_code_header(pdf, entity)
+      qr_code_png = QrCodeService.generate_qr_code(entity)
+      # Position QR code at top left of page
+      qr_width, qr_height = PositionCalculator.qr_code_dimensions
+      # Use pdf.bounds.top to position from top of page
+      image_options = {
+        at: [0, pdf.bounds.top],
+        width: qr_width,
+        height: qr_height
+      }
+      pdf.image StringIO.new(qr_code_png), image_options
+    end
+
     def self.render_qr_code_with_photo(pdf, entity, qr_code_png)
       photo_entity = entity.is_a?(Inspection) ? entity.unit : entity
       qr_x, qr_y = PositionCalculator.qr_code_position(pdf.bounds.width, pdf.page_number)
@@ -16,15 +29,14 @@ class PdfGeneratorService
     end
 
     def self.add_qr_code_overlay(pdf, qr_code_png, qr_x, qr_y)
-      pdf.transparent(0.5) do
-        qr_width, qr_height = PositionCalculator.qr_code_dimensions
-        image_options = {
-          at: [qr_x, qr_y],
-          width: qr_width,
-          height: qr_height
-        }
-        pdf.image StringIO.new(qr_code_png), image_options
-      end
+      # Render at 100% opacity (removed transparent wrapper)
+      qr_width, qr_height = PositionCalculator.qr_code_dimensions
+      image_options = {
+        at: [qr_x, qr_y],
+        width: qr_width,
+        height: qr_height
+      }
+      pdf.image StringIO.new(qr_code_png), image_options
     end
 
     def self.process_image_with_orientation(attachment)

--- a/app/services/pdf_generator_service/position_calculator.rb
+++ b/app/services/pdf_generator_service/position_calculator.rb
@@ -2,16 +2,13 @@ class PdfGeneratorService
   class PositionCalculator
     include Configuration
 
-    # Calculate QR code position in bottom right corner
-    # QR code's bottom-right corner aligns with table right edge, positioned above footer on first page
+    # Calculate QR code position in top left corner
+    # QR code's top-left corner aligns with page top left, matching header spacing
     def self.qr_code_position(pdf_bounds_width, pdf_page_number = 1)
-      x = pdf_bounds_width - QR_CODE_SIZE - QR_CODE_MARGIN
-      # On first page, position above footer; on other pages, use standard bottom offset
-      y = if pdf_page_number == 1
-        Configuration::FOOTER_HEIGHT + QR_CODE_BOTTOM_OFFSET + QR_CODE_SIZE
-      else
-        QR_CODE_BOTTOM_OFFSET + QR_CODE_SIZE
-      end
+      x = QR_CODE_MARGIN
+      # In Prawn, Y coordinates are from bottom, so we need to calculate from page top
+      # This positions the QR code at the very top of the page
+      y = QR_CODE_SIZE
       [x, y]
     end
 

--- a/app/services/qr_code_service.rb
+++ b/app/services/qr_code_service.rb
@@ -37,7 +37,7 @@ class QrCodeService
 
     qrcode.as_png(
       bit_depth: 1,
-      border_modules: 2,           # Less border space
+      border_modules: 0,           # No border for proper alignment
       color_mode: ChunkyPNG::COLOR_GRAYSCALE,
       color: "black",
       file: nil,

--- a/spec/services/pdf_generator_service/position_calculator_spec.rb
+++ b/spec/services/pdf_generator_service/position_calculator_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe PdfGeneratorService::PositionCalculator do
     context "with standard PDF width" do
       let(:pdf_width) { 500 }
 
-      it "calculates QR code position in bottom right corner" do
+      it "calculates QR code position in top left corner" do
         x, y = described_class.qr_code_position(pdf_width)
 
-        expected_x = pdf_width - qr_code_size - qr_code_margin
-        # QR code is on first page, so includes footer height
-        expected_y = PdfGeneratorService::Configuration::FOOTER_HEIGHT + qr_code_bottom_offset + qr_code_size
+        expected_x = qr_code_margin
+        # QR code is positioned at top of page
+        expected_y = qr_code_size
 
         expect(x).to eq(expected_x)
         expect(y).to eq(expected_y)
@@ -31,19 +31,19 @@ RSpec.describe PdfGeneratorService::PositionCalculator do
       it "handles narrow PDFs" do
         x, y = described_class.qr_code_position(pdf_width)
 
-        expected_x = pdf_width - qr_code_size - qr_code_margin
-        # QR code is on first page, so includes footer height
-        expected_y = PdfGeneratorService::Configuration::FOOTER_HEIGHT + qr_code_bottom_offset + qr_code_size
+        expected_x = qr_code_margin
+        # QR code is positioned at top of page
+        expected_y = qr_code_size
 
         expect(x).to eq(expected_x)
         expect(y).to eq(expected_y)
       end
 
-      it "may result in negative x for very narrow PDFs" do
+      it "always uses the same x position regardless of PDF width" do
         very_narrow_width = qr_code_size + qr_code_margin - 10
         x, _y = described_class.qr_code_position(very_narrow_width)
 
-        expect(x).to be < 0
+        expect(x).to eq(qr_code_margin)
       end
     end
 
@@ -53,9 +53,9 @@ RSpec.describe PdfGeneratorService::PositionCalculator do
       it "handles wide PDFs" do
         x, y = described_class.qr_code_position(pdf_width)
 
-        expected_x = pdf_width - qr_code_size - qr_code_margin
-        # QR code is on first page, so includes footer height
-        expected_y = PdfGeneratorService::Configuration::FOOTER_HEIGHT + qr_code_bottom_offset + qr_code_size
+        expected_x = qr_code_margin
+        # QR code is positioned at top of page
+        expected_y = qr_code_size
 
         expect(x).to eq(expected_x)
         expect(y).to eq(expected_y)


### PR DESCRIPTION
## Summary
- Relocates the QR code from the bottom right corner to the top left corner of PDF headers for inspections and units.
- Adjusts header text layout to accommodate the QR code on the left side.
- Updates QR code size calculation to be based on header text size for consistent scaling.
- Removes QR code rendering from footers and adds it to headers instead.
- Modifies position calculation logic and tests to reflect the new top-left placement.
- Ensures QR code is rendered at full opacity without transparency.

## Changes

### PDF Generation Service
- Removed QR code generation from footer sections in `PdfGeneratorService`.
- Added `generate_qr_code_header` method in `ImageProcessor` to render QR code at the top left.
- Updated header generators to include QR code rendering in the top left corner.
- Adjusted header text bounding boxes to shift right, making space for the QR code.

### Configuration
- Changed QR code size constant to be dynamically calculated based on header text size.
- Maintained zero margin to align QR code flush with the page edge.

### Position Calculation
- Updated `PositionCalculator` to compute QR code position at the top left instead of bottom right.
- Modified tests to verify QR code positioning at the top left corner for various PDF widths.

## Test plan
- Verified QR code appears in the top left corner of generated PDFs for inspections and units.
- Confirmed header text is properly shifted right and not overlapped by the QR code.
- Ran position calculator specs to ensure correct coordinate calculations.
- Checked that QR code opacity is fully opaque as intended.
- Ensured no QR code is rendered in the footer after the change.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/89c98b3d-3a4b-4850-960f-a3d20c7b4017