### PR TITLE
Add random indoor_use_only attribute to inspection factory

### DIFF
--- a/spec/factories/inspections.rb
+++ b/spec/factories/inspections.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
       width { 5.5 }
       length { 6.0 }
       height { 4.5 }
+      indoor_use_only { [true, false].sample }
 
       after(:create) do |inspection|
         inspection.reload


### PR DESCRIPTION
## Summary
- Adds a new attribute `indoor_use_only` to the inspection factory
- The attribute is randomly set to `true` or `false` for each created inspection

## Changes

### Test Factories
- **Inspection Factory**: Added `indoor_use_only` attribute with a random boolean value generated by `[true, false].sample`

## Test plan
- [x] Create inspections using the factory and verify that `indoor_use_only` is set randomly to `true` or `false`
- [x] Ensure no existing tests break due to the addition of the new attribute

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5b4df11a-578a-47dc-8709-95e7a6539bdc