### PR TITLE
Fix inspection incomplete fields validation by removing incorrect passed flag

### DIFF
--- a/spec/features/inspections/inspection_incomplete_fields_spec.rb
+++ b/spec/features/inspections/inspection_incomplete_fields_spec.rb
@@ -9,7 +9,6 @@ RSpec.feature "Inspection incomplete fields display", type: :feature do
     inspection = create(:inspection,
       unit:,
       user:,
-      passed: true,
       width: 5.0,
       length: 10.0,
       height: 3.0)


### PR DESCRIPTION
## Summary
- Fixes the validation issue in inspection incomplete fields feature
- Removes the incorrect `passed: true` attribute from inspection creation in the test

## Changes

### Test Fix
- Updated `spec/features/inspections/inspection_incomplete_fields_spec.rb` to remove `passed: true` from the inspection factory call
- This change ensures the inspection incomplete fields validation test reflects the correct inspection state

## Test plan
- [x] Run inspection incomplete fields feature spec to verify it passes without the `passed` flag
- [x] Confirm that the validation logic behaves correctly with the updated test setup

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/997b7be9-ed15-45fc-9204-c1329a6ecd22