### PR TITLE
Ignore Active Storage tables in N+1 query detection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -137,7 +137,13 @@ class ApplicationController < ActionController::Base
   def check_query_limit
     table_query_counts = count_queries_by_table
 
+    # Tables to ignore for N+1 detection (Active Storage tables)
+    ignored_tables = %w[active_storage_blobs active_storage_attachments]
+
     table_query_counts.each do |table, count|
+      # Skip checking for ignored tables
+      next if ignored_tables.include?(table)
+
       if count > 5
         log_n_plus_one_queries(table, count)
         # Log to Sentry instead of raising

--- a/config/locales/application.en.yml
+++ b/config/locales/application.en.yml
@@ -11,8 +11,8 @@ en:
       backtrace_label: "Backtrace (first 5 lines)"
 
     debug:
-      n_plus_one_detected: "N+1 query detected: %{table} table was queried %{count} times"
-      n_plus_one_with_limit: "N+1 query detected: %{table} table was queried %{count} times (limit: %{limit})"
+      n_plus_one_detected: "N+1 query detected: %{table} table was queried too many times"
+      n_plus_one_with_limit: "N+1 query detected: %{table} table was queried too many times"
       table_query_count: "%{table} was queried %{count} times"
       queries_for_table: "Queries for %{table}:"
       query_log_entry: "%{name}: %{sql}"


### PR DESCRIPTION
## Summary
- Updates N+1 query detection logic to ignore Active Storage tables (`active_storage_blobs` and `active_storage_attachments`)
- Modifies related log messages to use a more generic wording for detected N+1 queries

## Changes

### ApplicationController
- Added `ignored_tables` array containing Active Storage tables to exclude from N+1 query checks
- Skips N+1 detection for these tables in `check_query_limit` method

### Localization
- Updated N+1 query detection messages in `application.en.yml` to use "queried too many times" instead of specific counts

## Test plan
- Verify that N+1 query detection no longer triggers for Active Storage tables
- Confirm that other tables still trigger detection and logging as expected
- Check that log messages reflect the updated wording for N+1 queries

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/db47c7c9-3e10-414e-ad47-e269073c125d