### PR TITLE
Show IDs in Inspections and Units Tables

### DIFF
--- a/app/assets/stylesheets/inspections.css
+++ b/app/assets/stylesheets/inspections.css
@@ -112,6 +112,9 @@
 	}
 
 	/* Column widths for inspections table */
+	.inspections-list .col-id {
+		flex: 0 0 60px;
+	}
 	.inspections-list .col-photo {
 		flex: 0 0 80px;
 	}
@@ -139,6 +142,9 @@
 	}
 
 	/* Column widths for units table */
+	.units-list .col-id {
+		flex: 0 0 60px;
+	}
 	.units-list .col-photo {
 		flex: 0 0 80px;
 	}

--- a/app/views/inspections/_inspections_table.html.erb
+++ b/app/views/inspections/_inspections_table.html.erb
@@ -9,6 +9,7 @@
 <div class="table-list inspections-list">
   <!-- Header row -->
   <div class="table-list-header">
+    <span class="col-id"><%= t('inspections.fields.id') %></span>
     <% if show_photo %>
       <span class="col-photo"><%= t('units.fields.photo') %></span>
     <% end %>
@@ -36,6 +37,9 @@
       %>
       <li>
         <%= link_to target_path, class: "table-list-link" do %>
+          <span class="col-id" data-label="<%= t('inspections.fields.id') %>">
+            <%= inspection.id %>
+          </span>
           <% if show_photo %>
             <span class="col-photo" data-label="<%= t('units.fields.photo') %>">
               <% if !inspection.complete? && inspection.unit&.photo&.attached? %>

--- a/app/views/inspections/_inspections_table.html.erb
+++ b/app/views/inspections/_inspections_table.html.erb
@@ -9,10 +9,10 @@
 <div class="table-list inspections-list">
   <!-- Header row -->
   <div class="table-list-header">
-    <span class="col-id"><%= t('inspections.fields.id') %></span>
     <% if show_photo %>
       <span class="col-photo"><%= t('units.fields.photo') %></span>
     <% end %>
+    <span class="col-id"><%= t('inspections.fields.id') %></span>
     <% if show_name %>
       <span class="col-name"><%= t('inspections.fields.name') %></span>
     <% end %>
@@ -37,9 +37,6 @@
       %>
       <li>
         <%= link_to target_path, class: "table-list-link" do %>
-          <span class="col-id" data-label="<%= t('inspections.fields.id') %>">
-            <%= inspection.id %>
-          </span>
           <% if show_photo %>
             <span class="col-photo" data-label="<%= t('units.fields.photo') %>">
               <% if !inspection.complete? && inspection.unit&.photo&.attached? %>
@@ -55,6 +52,9 @@
               <% end %>
             </span>
           <% end %>
+          <span class="col-id" data-label="<%= t('inspections.fields.id') %>">
+            <%= inspection.id %>
+          </span>
           <% if show_name %>
             <span class="col-name" data-label="<%= t('inspections.fields.name') %>">
               <% if inspection.unit.nil? %>

--- a/app/views/units/_unit_table.html.erb
+++ b/app/views/units/_unit_table.html.erb
@@ -1,8 +1,8 @@
 <div class="table-list units-list">
   <!-- Header row -->
   <div class="table-list-header">
-    <span class="col-id"><%= t('units.fields.id') %></span>
     <span class="col-photo"><%= t('units.fields.photo') %></span>
+    <span class="col-id"><%= t('units.fields.id') %></span>
     <span class="col-name"><%= t('units.fields.name') %></span>
     <span class="col-manufacturer"><%= t('units.fields.manufacturer') %></span>
     <span class="col-serial"><%= t('units.fields.serial') %></span>
@@ -13,9 +13,6 @@
     <% unit.each do |item| %>
       <li>
         <%= link_to item, class: "table-list-link" do %>
-          <span class="col-id" data-label="<%= t('units.fields.id') %>">
-            <%= item.id %>
-          </span>
           <span class="col-photo" data-label="<%= t('units.fields.photo') %>">
             <% if item.photo.attached? %>
               <%= render 'shared/image',
@@ -28,6 +25,9 @@
                   width: 60,
                   height: 60 %>
             <% end %>
+          </span>
+          <span class="col-id" data-label="<%= t('units.fields.id') %>">
+            <%= item.id %>
           </span>
           <span class="col-name" data-label="<%= t('units.fields.name') %>">
             <%= item.name %>

--- a/app/views/units/_unit_table.html.erb
+++ b/app/views/units/_unit_table.html.erb
@@ -1,6 +1,7 @@
 <div class="table-list units-list">
   <!-- Header row -->
   <div class="table-list-header">
+    <span class="col-id"><%= t('units.fields.id') %></span>
     <span class="col-photo"><%= t('units.fields.photo') %></span>
     <span class="col-name"><%= t('units.fields.name') %></span>
     <span class="col-manufacturer"><%= t('units.fields.manufacturer') %></span>
@@ -12,6 +13,9 @@
     <% unit.each do |item| %>
       <li>
         <%= link_to item, class: "table-list-link" do %>
+          <span class="col-id" data-label="<%= t('units.fields.id') %>">
+            <%= item.id %>
+          </span>
           <span class="col-photo" data-label="<%= t('units.fields.photo') %>">
             <% if item.photo.attached? %>
               <%= render 'shared/image',

--- a/config/locales/units.en.yml
+++ b/config/locales/units.en.yml
@@ -48,6 +48,7 @@ en:
       other_dimensions: "Other Specifications"
 
     fields:
+      id: "ID"
       name: "Unit Name"
       serial: "Serial"
       manufacturer: "Manufacturer"


### PR DESCRIPTION
## Summary
- Adds display of IDs in the inspections and units index tables
- Updates table headers and rows to include ID columns
- Adjusts CSS to allocate space for the new ID columns
- Adds localization for the ID field label

## Changes

### UI Updates
- **Inspections Table**: Added an ID column header and corresponding ID values in each row
- **Units Table**: Added an ID column header and corresponding ID values in each row

### Styling
- Updated `inspections.css` to define fixed widths for the new ID columns in both inspections and units tables

### Localization
- Added `id` field label to `units.en.yml` for proper translation display

## Test plan
- [x] Verify that the ID column appears in the inspections table with correct values
- [x] Verify that the ID column appears in the units table with correct values
- [x] Check that the tables maintain proper layout and styling with the new columns
- [x] Confirm that the ID label is correctly localized and displayed

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/23a36efb-66c2-474b-8e2b-b321bcb1307b