### PR TITLE
Fix PDF disclaimer width based on user signature presence

### DIFF
--- a/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
+++ b/app/services/pdf_generator_service/disclaimer_footer_renderer.rb
@@ -34,8 +34,9 @@ class PdfGeneratorService
 
       pdf.move_down FOOTER_INTERNAL_PADDING
 
-      # Calculate widths
-      disclaimer_width = pdf.bounds.width * DISCLAIMER_TEXT_WIDTH_PERCENT
+      # Calculate widths based on whether signature exists
+      has_signature = user&.signature&.attached?
+      disclaimer_width = has_signature ? (pdf.bounds.width * DISCLAIMER_TEXT_WIDTH_PERCENT) : pdf.bounds.width
       signature_width = pdf.bounds.width * (1 - DISCLAIMER_TEXT_WIDTH_PERCENT)
 
       # Both disclaimer and signature should be vertically aligned
@@ -51,7 +52,7 @@ class PdfGeneratorService
       end
 
       # Signature on the right if user has one
-      if user&.signature&.attached?
+      if has_signature
         # Position signature aligned with disclaimer text area
         render_user_signature(pdf, user, disclaimer_width, signature_width, content_top_y)
       end


### PR DESCRIPTION
## Summary
- Adjusts the width calculation of the PDF disclaimer text based on whether the user has a signature attached
- Ensures the disclaimer uses full width if no signature is present
- Keeps the original width split between disclaimer and signature when a signature exists

## Changes

### PDF Generator Service
- Modified `disclaimer_footer_renderer.rb` to:
  - Introduce a `has_signature` flag to check if the user has an attached signature
  - Calculate `disclaimer_width` as full width if no signature, otherwise use the predefined percentage
  - Use the `has_signature` flag to conditionally render the user signature in the PDF footer

## Test plan
- [x] Generate PDFs with users having signatures and verify disclaimer and signature widths
- [x] Generate PDFs with users without signatures and verify disclaimer uses full width
- [x] Confirm no layout regressions in the PDF footer rendering

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c1e4e240-f3bf-447b-9112-fec503625f13