### PR TITLE
Add homepage search box for Unit or Inspection ID

### DIFF
--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -8,6 +8,13 @@
 
 <%= @page.safe_content %>
 
+<% if @page.slug == "/" %>
+  <form action="/search" method="get">
+    <input type="text" name="id" placeholder="<%= t('search.homepage.placeholder') %>" pattern="[A-Za-z0-9]{8}" required>
+    <button type="submit">🔍</button>
+  </form>
+<% end %>
+
 <% if @page.slug == "/" && !current_user %>
   <nav>
     <ul>

--- a/config/locales/search.en.yml
+++ b/config/locales/search.en.yml
@@ -2,6 +2,8 @@ en:
   # Search functionality
   search:
     title: "Search Federated Sites"
+    homepage:
+      placeholder: "Unit or Inspection ID"
     sites:
       current_site: "Current Site"
       play_test: "Play Test"


### PR DESCRIPTION
## Summary
- Adds a search box to the homepage for searching by Unit or Inspection ID
- Search input accepts exactly 8 alphanumeric characters
- Placeholder text localized for better user guidance

## Changes

### Frontend
- Added a search form to the homepage (`/`) in `app/views/pages/show.html.erb`
  - Input field with pattern validation for 8 alphanumeric characters
  - Submit button with search icon

### Localization
- Added new translation key `search.homepage.placeholder` with value "Unit or Inspection ID" in `config/locales/search.en.yml`

## Test plan
- [x] Visit homepage and verify search box is visible
- [x] Confirm placeholder text is "Unit or Inspection ID"
- [x] Test input validation by entering invalid and valid IDs
- [x] Submit form and verify it sends a GET request to `/search` with the entered ID
- [x] Ensure search box does not appear on other pages

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/22d37bae-dbc8-4c0d-93c3-10716ad8ce75