### PR TITLE
Refactor PDF locale keys to use forms namespace

### DIFF
--- a/app/services/pdf_generator_service/table_builder.rb
+++ b/app/services/pdf_generator_service/table_builder.rb
@@ -215,13 +215,13 @@ class PdfGeneratorService
 
       if last_inspection
         if last_inspection.width.present?
-          dimensions << "#{I18n.t("pdf.dimensions.width")}: #{Utilities.format_dimension(last_inspection.width)}"
+          dimensions << "#{I18n.t("forms.inspection.fields.width").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.width)}"
         end
         if last_inspection.length.present?
-          dimensions << "#{I18n.t("pdf.dimensions.length")}: #{Utilities.format_dimension(last_inspection.length)}"
+          dimensions << "#{I18n.t("forms.inspection.fields.length").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.length)}"
         end
         if last_inspection.height.present?
-          dimensions << "#{I18n.t("pdf.dimensions.height")}: #{Utilities.format_dimension(last_inspection.height)}"
+          dimensions << "#{I18n.t("forms.inspection.fields.height").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.height)}"
         end
       end
       dimensions_text = dimensions.any? ? dimensions.join(" ") : ""
@@ -230,9 +230,9 @@ class PdfGeneratorService
       [
         [I18n.t("units.fields.name"),
           Utilities.truncate_text(unit.name, UNIT_NAME_MAX_LENGTH)],
-        [I18n.t("pdf.inspection.fields.manufacturer"), unit.manufacturer],
-        [I18n.t("pdf.inspection.fields.operator"), unit.operator],
-        [I18n.t("pdf.inspection.fields.serial"), unit.serial],
+        [I18n.t("forms.units.fields.manufacturer"), unit.manufacturer],
+        [I18n.t("forms.units.fields.operator"), unit.operator],
+        [I18n.t("forms.units.fields.serial"), unit.serial],
         [I18n.t("pdf.inspection.fields.size_m"), dimensions_text]
       ]
     end
@@ -242,13 +242,13 @@ class PdfGeneratorService
 
       if last_inspection
         if last_inspection.width.present?
-          dimensions << "#{I18n.t("pdf.dimensions.width")}: #{Utilities.format_dimension(last_inspection.width)}"
+          dimensions << "#{I18n.t("forms.inspection.fields.width").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.width)}"
         end
         if last_inspection.length.present?
-          dimensions << "#{I18n.t("pdf.dimensions.length")}: #{Utilities.format_dimension(last_inspection.length)}"
+          dimensions << "#{I18n.t("forms.inspection.fields.length").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.length)}"
         end
         if last_inspection.height.present?
-          dimensions << "#{I18n.t("pdf.dimensions.height")}: #{Utilities.format_dimension(last_inspection.height)}"
+          dimensions << "#{I18n.t("forms.inspection.fields.height").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.height)}"
         end
       end
       dimensions_text = dimensions.any? ? dimensions.join(" ") : ""
@@ -282,19 +282,19 @@ class PdfGeneratorService
           inspector_text
         ],
         [
-          I18n.t("pdf.inspection.fields.description"),
+          I18n.t("forms.units.fields.description"),
           unit.description,
-          I18n.t("pdf.inspection.fields.manufacturer"),
+          I18n.t("forms.units.fields.manufacturer"),
           unit.manufacturer
         ],
         [
           I18n.t("pdf.inspection.fields.size_m"),
           dimensions_text,
-          I18n.t("pdf.inspection.fields.operator"),
+          I18n.t("forms.units.fields.operator"),
           unit.operator
         ],
         [
-          I18n.t("pdf.inspection.fields.serial"),
+          I18n.t("forms.units.fields.serial"),
           unit.serial,
           I18n.t("pdf.inspection.fields.issued_date"),
           issued_date

--- a/app/services/pdf_generator_service/table_builder.rb
+++ b/app/services/pdf_generator_service/table_builder.rb
@@ -215,13 +215,13 @@ class PdfGeneratorService
 
       if last_inspection
         if last_inspection.width.present?
-          dimensions << "#{I18n.t("forms.inspection.fields.width").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.width)}"
+          dimensions << "#{FieldUtils.form_field_label("inspection", "width").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.width)}"
         end
         if last_inspection.length.present?
-          dimensions << "#{I18n.t("forms.inspection.fields.length").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.length)}"
+          dimensions << "#{FieldUtils.form_field_label("inspection", "length").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.length)}"
         end
         if last_inspection.height.present?
-          dimensions << "#{I18n.t("forms.inspection.fields.height").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.height)}"
+          dimensions << "#{FieldUtils.form_field_label("inspection", "height").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.height)}"
         end
       end
       dimensions_text = dimensions.any? ? dimensions.join(" ") : ""
@@ -230,9 +230,9 @@ class PdfGeneratorService
       [
         [I18n.t("units.fields.name"),
           Utilities.truncate_text(unit.name, UNIT_NAME_MAX_LENGTH)],
-        [I18n.t("forms.units.fields.manufacturer"), unit.manufacturer],
-        [I18n.t("forms.units.fields.operator"), unit.operator],
-        [I18n.t("forms.units.fields.serial"), unit.serial],
+        [FieldUtils.form_field_label("units", "manufacturer"), unit.manufacturer],
+        [FieldUtils.form_field_label("units", "operator"), unit.operator],
+        [FieldUtils.form_field_label("units", "serial"), unit.serial],
         [I18n.t("pdf.inspection.fields.size_m"), dimensions_text]
       ]
     end
@@ -242,13 +242,13 @@ class PdfGeneratorService
 
       if last_inspection
         if last_inspection.width.present?
-          dimensions << "#{I18n.t("forms.inspection.fields.width").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.width)}"
+          dimensions << "#{FieldUtils.form_field_label("inspection", "width").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.width)}"
         end
         if last_inspection.length.present?
-          dimensions << "#{I18n.t("forms.inspection.fields.length").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.length)}"
+          dimensions << "#{FieldUtils.form_field_label("inspection", "length").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.length)}"
         end
         if last_inspection.height.present?
-          dimensions << "#{I18n.t("forms.inspection.fields.height").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.height)}"
+          dimensions << "#{FieldUtils.form_field_label("inspection", "height").sub(" (m)", "")}: #{Utilities.format_dimension(last_inspection.height)}"
         end
       end
       dimensions_text = dimensions.any? ? dimensions.join(" ") : ""
@@ -282,19 +282,19 @@ class PdfGeneratorService
           inspector_text
         ],
         [
-          I18n.t("forms.units.fields.description"),
+          FieldUtils.form_field_label("units", "description"),
           unit.description,
-          I18n.t("forms.units.fields.manufacturer"),
+          FieldUtils.form_field_label("units", "manufacturer"),
           unit.manufacturer
         ],
         [
           I18n.t("pdf.inspection.fields.size_m"),
           dimensions_text,
-          I18n.t("forms.units.fields.operator"),
+          FieldUtils.form_field_label("units", "operator"),
           unit.operator
         ],
         [
-          I18n.t("forms.units.fields.serial"),
+          FieldUtils.form_field_label("units", "serial"),
           unit.serial,
           I18n.t("pdf.inspection.fields.issued_date"),
           issued_date

--- a/config/locales/pdf.en.yml
+++ b/config/locales/pdf.en.yml
@@ -13,8 +13,6 @@ en:
       watermark:
         draft: "DRAFT"
       fields:
-        serial: "Serial Number"
-        manufacturer: "Manufacturer"
         inspector: "Inspector"
         inspected_by: "Inspected by"
         issued: "Issued"
@@ -22,16 +20,11 @@ en:
         expiry_date: "Expiry Date"
         rpii_inspector_no: "RPII Inspector No"
         report_id: "Report ID"
-        description: "Description"
-        operator: "Operator"
         size_m: "Size (m)"
         passed: "PASSED"
         failed: "FAILED"
         incomplete: "INCOMPLETE"
         na: "N/A"
-        width: "Width"
-        length: "Length"
-        height: "Height"
         size: "Size"
         size_with_unit: "Size (m)"
         unit_meters: "m"
@@ -52,10 +45,6 @@ en:
       no_completed_inspections: "No completed inspections"
       fields:
         unit_id: "Unit ID"
-        description: "Description"
-        serial: "Serial Number"
-        manufacturer: "Manufacturer"
-        operator: "Operator"
         size_m: "Size (m)"
         date: "Date"
         inspector: "Inspector"
@@ -65,9 +54,6 @@ en:
         na: "N/A"
 
     dimensions:
-      width: "Width"
-      length: "Length"
-      height: "Height"
       size: "Size"
       size_with_unit: "Size (m)"
       unit_meters: "m"

--- a/lib/field_utils.rb
+++ b/lib/field_utils.rb
@@ -34,4 +34,8 @@ module FieldUtils
   def self.base_field_name(field)
     strip_field_suffix(field)
   end
+
+  def self.form_field_label(form, field)
+    I18n.t("forms.#{form}.fields.#{field}")
+  end
 end

--- a/spec/features/pdfs/pdf_comprehensive_spec.rb
+++ b/spec/features/pdfs/pdf_comprehensive_spec.rb
@@ -41,10 +41,7 @@ RSpec.feature "PDF Comprehensive Testing", type: :feature do
 
     # Test i18n usage
     expect_pdf_to_include_i18n_keys(pdf_content,
-      "pdf.inspection.equipment_details",
-      "pdf.dimensions.width",
-      "pdf.dimensions.length",
-      "pdf.dimensions.height")
+      "pdf.inspection.equipment_details")
 
     # === EDGE CASE TESTING ===
     # Test with long comments (performance)

--- a/spec/features/pdfs/pdf_integration_spec.rb
+++ b/spec/features/pdfs/pdf_integration_spec.rb
@@ -90,10 +90,7 @@ RSpec.feature "PDF Complete Integration", type: :feature do
     # Validate key i18n strings are used
     expect_pdf_to_include_i18n_keys(pdf_content,
       "pdf.inspection.equipment_details",
-      "pdf.inspection.assessments_section",
-      "pdf.dimensions.width",
-      "pdf.dimensions.length",
-      "pdf.dimensions.height")
+      "pdf.inspection.assessments_section")
 
     # Validate unit details
     expect(pdf_content).to include(unit.manufacturer)

--- a/spec/services/pdf_generator_service_spec.rb
+++ b/spec/services/pdf_generator_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PdfGeneratorService, pdf: true do
         pdf_text = pdf_text_content(pdf.render)
 
         # Manufacturer field should be blank (empty string) when not specified
-        expect(pdf_text).to include(I18n.t("pdf.inspection.fields.manufacturer"))
+        expect(pdf_text).to include(I18n.t("forms.units.fields.manufacturer"))
         # The actual value after the manufacturer label should be empty/blank
       end
     end
@@ -70,9 +70,9 @@ RSpec.describe PdfGeneratorService, pdf: true do
       pdf_text = pdf_text_content(pdf.render)
 
       expect(pdf_text).to include(I18n.t("units.fields.name"))
-      expect(pdf_text).to include(I18n.t("pdf.inspection.fields.serial"))
-      expect(pdf_text).to include(I18n.t("pdf.inspection.fields.manufacturer"))
-      expect(pdf_text).to include(I18n.t("pdf.inspection.fields.operator"))
+      expect(pdf_text).to include(I18n.t("forms.units.fields.serial"))
+      expect(pdf_text).to include(I18n.t("forms.units.fields.manufacturer"))
+      expect(pdf_text).to include(I18n.t("forms.units.fields.operator"))
     end
 
     context "with inspections" do
@@ -103,7 +103,7 @@ RSpec.describe PdfGeneratorService, pdf: true do
         pdf_text = pdf_text_content(pdf.render)
 
         # Manufacturer field should be blank (empty string) when not specified
-        expect(pdf_text).to include(I18n.t("pdf.inspection.fields.manufacturer"))
+        expect(pdf_text).to include(I18n.t("forms.units.fields.manufacturer"))
         # The actual value after the manufacturer label should be empty/blank
       end
     end


### PR DESCRIPTION
## Summary
- Refactored PDF generation to replace locale keys from `pdf` namespace to `forms` namespace
- Removed redundant dimension keys from `pdf.en.yml` locale file
- Updated specs to expect new locale keys under `forms` namespace

## Changes

### PDF Generator Service
- Updated `table_builder.rb` to use `forms.inspection.fields` and `forms.units.fields` locale keys instead of `pdf.dimensions` and `pdf.inspection.fields`
- Removed unit labels like width, length, height from PDF locale file as they are now sourced from forms locale

### Locale Files
- Deleted dimension and unit-related keys from `config/locales/pdf.en.yml` that were duplicated in forms locale

### Tests
- Modified feature and service specs to expect new locale keys under `forms` namespace
- Removed checks for old `pdf.dimensions` keys in PDF content tests

## Test plan
- [x] Run all PDF generation specs to ensure locale keys are correctly resolved
- [x] Verify PDF content includes updated labels from `forms` locale keys
- [x] Confirm no missing translation errors for PDF fields after refactor

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4bcd6c0c-ef2b-491e-9d61-7a5619311118