### PR TITLE
Optimize ERB linting with incremental runner and enhanced Rake tasks

### DIFF
--- a/lib/erb_lint_runner.rb
+++ b/lib/erb_lint_runner.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Runs erb_lint on files one at a time with progress output
+# rubocop:disable Rails/Output
 class ErbLintRunner
   def initialize(autocorrect: false, verbose: false)
     @autocorrect = autocorrect
@@ -44,7 +45,7 @@ class ErbLintRunner
     files = []
     patterns.each do |pattern|
       Dir.glob(Rails.root.join(pattern).to_s).each do |file|
-        relative_path = file.sub("#{Rails.root}/", "")
+        relative_path = file.sub(Rails.root.to_s + "/", "")
         next if exclude_dirs.any? { |dir| relative_path.start_with?(dir) }
         files << relative_path
       end
@@ -56,21 +57,21 @@ class ErbLintRunner
   def process_file(file, current, total)
     print "[#{current}/#{total}] #{file.ljust(60)} "
     $stdout.flush
-    
-    start_time = Time.now
+
+    start_time = Time.current
     command = build_command(file)
-    
+
     output = `#{command} 2>&1`
     success = $?.success?
-    elapsed = (Time.now - start_time).round(2)
+    elapsed = (Time.current - start_time).round(2)
 
     if success
       puts "✅ (#{elapsed}s)"
     else
       violations = extract_violation_count(output)
       @total_violations += violations
-      @failed_files << { file: file, violations: violations, output: output }
-      
+      @failed_files << {file:, violations:, output:}
+
       # Show slow linter warning if it took too long
       if elapsed > 5.0
         puts "❌ #{violations} violation(s) (#{elapsed}s) ⚠️  SLOW"
@@ -86,7 +87,7 @@ class ErbLintRunner
     @processed += 1
   rescue => e
     puts "💥 Error: #{e.message}"
-    @failed_files << { file: file, violations: 0, output: e.message }
+    @failed_files << {file:, violations: 0, output: e.message}
   end
 
   def build_command(file)
@@ -123,3 +124,4 @@ class ErbLintRunner
     end
   end
 end
+# rubocop:enable Rails/Output

--- a/lib/erb_lint_runner.rb
+++ b/lib/erb_lint_runner.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Runs erb_lint on files one at a time with progress output
+class ErbLintRunner
+  def initialize(autocorrect: false, verbose: false)
+    @autocorrect = autocorrect
+    @verbose = verbose
+    @processed = 0
+    @total_violations = 0
+    @failed_files = []
+  end
+
+  def run_on_all_files
+    erb_files = find_erb_files
+    puts "Found #{erb_files.length} ERB files to lint..."
+    puts "=" * 80
+
+    erb_files.each_with_index do |file, index|
+      process_file(file, index + 1, erb_files.length)
+    end
+
+    print_summary
+    @failed_files.empty?
+  end
+
+  def run_on_files(files)
+    puts "Linting #{files.length} ERB files..."
+    puts "=" * 80
+
+    files.each_with_index do |file, index|
+      process_file(file, index + 1, files.length)
+    end
+
+    print_summary
+    @failed_files.empty?
+  end
+
+  private
+
+  def find_erb_files
+    patterns = ["**/*.erb", "**/*.html.erb"]
+    exclude_dirs = ["vendor", "node_modules", "tmp", "public"]
+
+    files = []
+    patterns.each do |pattern|
+      Dir.glob(Rails.root.join(pattern).to_s).each do |file|
+        relative_path = file.sub("#{Rails.root}/", "")
+        next if exclude_dirs.any? { |dir| relative_path.start_with?(dir) }
+        files << relative_path
+      end
+    end
+
+    files.uniq.sort
+  end
+
+  def process_file(file, current, total)
+    print "[#{current}/#{total}] #{file.ljust(60)} "
+    $stdout.flush
+    
+    start_time = Time.now
+    command = build_command(file)
+    
+    output = `#{command} 2>&1`
+    success = $?.success?
+    elapsed = (Time.now - start_time).round(2)
+
+    if success
+      puts "✅ (#{elapsed}s)"
+    else
+      violations = extract_violation_count(output)
+      @total_violations += violations
+      @failed_files << { file: file, violations: violations, output: output }
+      
+      # Show slow linter warning if it took too long
+      if elapsed > 5.0
+        puts "❌ #{violations} violation(s) (#{elapsed}s) ⚠️  SLOW"
+        if @verbose
+          puts "  Slow file details:"
+          puts output.lines.grep(/\A\s*\d+:\d+/).first(3).map { |line| "    #{line.strip}" }
+        end
+      else
+        puts "❌ #{violations} violation(s) (#{elapsed}s)"
+      end
+    end
+
+    @processed += 1
+  rescue => e
+    puts "💥 Error: #{e.message}"
+    @failed_files << { file: file, violations: 0, output: e.message }
+  end
+
+  def build_command(file)
+    cmd = "bundle exec erb_lint #{file}"
+    cmd += " --autocorrect" if @autocorrect
+    cmd
+  end
+
+  def extract_violation_count(output)
+    # erb_lint output format: "1 error(s) were found"
+    match = output.match(/(\d+) error\(s\) were found/)
+    match ? match[1].to_i : 1
+  end
+
+  def print_summary
+    puts "=" * 80
+    puts "\nSUMMARY:"
+    puts "Processed: #{@processed} files"
+    puts "Failed: #{@failed_files.length} files"
+    puts "Total violations: #{@total_violations}"
+
+    if @failed_files.any?
+      puts "\nFailed files:"
+      @failed_files.each do |failure|
+        puts "  #{failure[:file]} (#{failure[:violations]} violation(s))"
+      end
+
+      if !@autocorrect
+        puts "\nTo fix these issues, run:"
+        puts "  rake code_standards:erb_lint_fix"
+      end
+    else
+      puts "\n✅ All ERB files passed linting!"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces `ErbLintRunner` class to run `erb_lint` on ERB files one at a time with progress and detailed output
- Replaces bulk `erb_lint` calls in Rake tasks with incremental linting for better performance and feedback
- Adds verbose mode to show detailed linting info for slow files
- Updates `code_standards` Rake tasks to use the new runner for all, fixed, modified, and verbose linting

## Changes

### Core Functionality
- **ErbLintRunner**: New class in `lib/erb_lint_runner.rb` that:
  - Finds ERB files excluding vendor, node_modules, tmp, and public directories
  - Runs `erb_lint` on each file individually with timing and violation count
  - Supports autocorrect and verbose modes
  - Prints progress, slow file warnings, and a summary of results

### Rake Tasks
- Modified `code_standards.rake` tasks:
  - `erb_lint`, `erb_lint_fix`, `erb_lint_modified`, and new `erb_lint_verbose` use `ErbLintRunner`
  - Improved output clarity and failure handling with exit codes
  - `fix_all` task updated to run `erb_lint` one file at a time with autocorrect

## Test plan
- Run `rake code_standards:erb_lint` to verify linting all ERB files with progress output
- Run `rake code_standards:erb_lint_fix` to verify autocorrect functionality
- Modify ERB files and run `rake code_standards:erb_lint_modified` to lint only changed files
- Run `rake code_standards:erb_lint_verbose` to check verbose output for slow files
- Confirm `fix_all` task runs StandardRB and ERB linting with autocorrect sequentially
- Validate exit codes on lint failures

This enhancement improves developer feedback during linting and optimizes the linting workflow for ERB files.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/11f4ff9b-a015-4747-9c16-a3a41d41d37f