### PR TITLE
Fix N+1 Query, Handle PgQuery Parse Errors, and Refactor InspectionsController Code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -135,6 +135,10 @@ class ApplicationController < ActionController::Base
   def n_plus_one_detection
     Prosopite.scan
     yield
+  rescue PgQuery::ParseError => e
+    # PgQuery can't parse queries with bind parameters - ignore these errors
+    Rails.logger.debug { "Prosopite: Skipping query due to parse error: #{e.message}" }
+    yield
   ensure
     Prosopite.finish
   end

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -202,12 +202,12 @@ class InspectionsController < ApplicationController
 
   def partition_inspections(all_inspections)
     @draft_inspections = all_inspections
-      .select { it.complete_date.nil? }
+      .select { _1.complete_date.nil? }
       .sort_by(&:created_at)
 
     @complete_inspections = all_inspections
-      .select { it.complete_date.present? }
-      .sort_by { -it.created_at.to_i }
+      .select { _1.complete_date.present? }
+      .sort_by { -_1.created_at.to_i }
   end
 
   def send_inspections_csv
@@ -289,11 +289,11 @@ class InspectionsController < ApplicationController
   def assessment_permitted_attributes(assessment_type)
     model_class = "Assessments::#{assessment_type.to_s.camelize}".constantize
     all_attributes = model_class.column_names
-    (all_attributes - ASSESSMENT_SYSTEM_ATTRIBUTES).map { it.to_sym }
+    (all_attributes - ASSESSMENT_SYSTEM_ATTRIBUTES).map { _1.to_sym }
   end
 
   def filtered_inspections_query_without_order = current_user.inspections
-    .includes(:inspector_company, unit: {photo_attachment: :blob})
+    .includes(:inspector_company, :user, unit: {photo_attachment: :blob})
     .search(params[:query])
     .filter_by_result(params[:result])
     .filter_by_unit(params[:unit_id])


### PR DESCRIPTION
## Summary
- Fixes N+1 query issue by including the `user` association in inspections query
- Adds error handling for `PgQuery::ParseError` in `n_plus_one_detection` to skip queries with bind parameters
- Refactors code to use Ruby 2.7+ numbered block parameters for cleaner syntax

## Changes

### ApplicationController
- Updated `n_plus_one_detection` method to rescue `PgQuery::ParseError` and log debug message, then continue yielding

### InspectionsController
- Updated `partition_inspections` method to use numbered block parameters (`_1`) instead of `it`
- Refactored `assessment_permitted_attributes` method to use numbered block parameters
- Modified `filtered_inspections_query_without_order` to include `:user` association along with existing includes to prevent N+1 queries

## Test plan
- [ ] Verify inspections listing loads without N+1 queries
- [ ] Confirm inspections are correctly partitioned into draft and complete
- [ ] Ensure permitted attributes for assessments are correctly filtered
- [ ] Confirm no errors occur in `n_plus_one_detection` when queries have bind parameters
- [ ] Run existing controller tests to validate no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/549331d2-d1e6-4622-a683-3ab0d7d6918a