### PR TITLE
Fix S3 backup database path for multi-database configs

### DIFF
--- a/app/services/concerns/s3_backup_operations.rb
+++ b/app/services/concerns/s3_backup_operations.rb
@@ -20,11 +20,17 @@ module S3BackupOperations
 
   def database_path
     db_config = Rails.configuration.database_configuration[Rails.env]
+
+    # Handle multi-database configuration (e.g., production with primary/queue)
+    if db_config.is_a?(Hash) && db_config.key?("primary")
+      db_config = db_config["primary"]
+    end
+
     unless db_config && db_config["database"]
       error_msg = "Database configuration missing for #{Rails.env} environment"
       Sentry.capture_message(error_msg, level: "error", extra: {
         rails_env: Rails.env,
-        db_config: db_config
+        db_config: Rails.configuration.database_configuration[Rails.env]
       })
       raise error_msg
     end


### PR DESCRIPTION
## Summary
- Fixes S3 backup operation to correctly handle multi-database configurations
- Specifically addresses cases where the database config includes a primary/queue setup
- Improves error reporting by capturing the full database configuration in Sentry

## Changes

### S3BackupOperations Module
- Updated `database_path` method to check if the database configuration is a hash with a `primary` key
- If so, uses the `primary` database config for the backup path
- Enhanced error logging to include the entire database configuration for the current environment

## Test plan
- Verified that the backup process correctly identifies the primary database in multi-db setups
- Confirmed that errors are logged with detailed config information when database config is missing
- Ran existing backup tests to ensure no regressions in single database environments

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/700a60f9-5c41-4bfb-9c3f-5cef9768e4dd