### PR TITLE
Fix app name from PatLogger to PlayTest

### DIFF
--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,5 @@
 {
-  "name": "PatLogger",
+  "name": "PlayTest",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +16,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "PatLogger.",
+  "description": "PlayTest.",
   "theme_color": "red",
   "background_color": "red"
 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ require "dotenv/load"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module PatLogger
+module PlayTest
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2


### PR DESCRIPTION
## Summary
- Corrects the application name from "PatLogger" to "PlayTest" in the manifest and application configuration

## Changes

### Manifest Update
- Updated `app/views/pwa/manifest.json.erb` to change the `name` and `description` fields from "PatLogger" to "PlayTest"

### Application Module Rename
- Renamed the main application module in `config/application.rb` from `PatLogger` to `PlayTest` to reflect the correct app name

## Test plan
- Verify the PWA manifest displays the correct app name and description
- Confirm the Rails application loads without module name conflicts or errors

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ddf8d9b1-786a-4cc4-a572-5523aebc9451