### PR TITLE
Update RPII theme with tiled faded logo background and centered logo styling

### DIFF
--- a/app/assets/stylesheets/rpii_theme.css
+++ b/app/assets/stylesheets/rpii_theme.css
@@ -5,7 +5,7 @@
 	background-image: url('rpii-logo-faded.png');
 	background-repeat: repeat;
 	background-attachment: fixed;
-	background-size: 200px auto;
+	background-size: 149px 117px;
 	background-position: center;
 }
 

--- a/app/assets/stylesheets/rpii_theme.css
+++ b/app/assets/stylesheets/rpii_theme.css
@@ -1,4 +1,14 @@
 /* RPII Theme - Based on light theme with RPII blue (#0e5dc7) */
+
+/* Background with tiled faded logo */
+.rpii {
+	background-image: url('rpii-logo-faded.png');
+	background-repeat: repeat;
+	background-attachment: fixed;
+	background-size: 200px auto;
+	background-position: center;
+}
+
 .rpii nav a,
 .rpii nav button {
 	background-color: #0e5dc7;
@@ -89,12 +99,11 @@
 	--color-table: #194eb1;
 }
 
-/* Logo container for two logos */
+/* Logo container for centered logo */
 .rpii .logo-container {
 	display: flex;
-	justify-content: space-between;
+	justify-content: center;
 	align-items: center;
-	padding: 0.5rem 1rem;
 	padding: 0.5rem 1rem;
 	max-width: var(--width-content);
 	margin: 0 auto 1rem;
@@ -105,12 +114,12 @@
 }
 
 .rpii .logo.right {
-	justify-content: flex-end;
+	justify-content: center;
 }
 
 .rpii .logo img {
 	width: auto;
-	height: 60px;
+	height: 80px;
 }
 
 .rpii main form {


### PR DESCRIPTION
## Summary
- Adds a tiled, faded RPII logo as a fixed background image for the RPII theme
- Centers the logo container and individual logos for a cleaner layout
- Increases logo image height from 60px to 80px for better visibility
- Adjusts background size to 149px by 117px for better fit

## Changes

### Stylesheet Updates
- Introduced `.rpii` class with a background image using `rpii-logo-faded.png`:
  - Background repeats and is fixed
  - Size set to 149px width and 117px height
  - Positioned at center
- Modified `.rpii .logo-container` to use `justify-content: center` instead of space-between for centering logos
- Adjusted `.rpii .logo.right` to center content instead of aligning right
- Increased `.rpii .logo img` height from 60px to 80px

## Test plan
- Verify the faded logo background appears tiled and fixed when scrolling
- Confirm logos are centered horizontally within the container
- Check that logo images display at the new height without distortion
- Ensure no regressions in navigation link/button background colors or other theme styles

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/008f9696-e158-429b-876a-c825025610ad
