### PR TITLE
Fix transparent PNG background rendering with white fill

### DIFF
--- a/app/javascript/image_resize.js
+++ b/app/javascript/image_resize.js
@@ -153,6 +153,10 @@ class ImageResize {
 					// Clear canvas first
 					ctx.clearRect(0, 0, width, height);
 
+					// Fill with white background for transparent images
+					ctx.fillStyle = "#FFFFFF";
+					ctx.fillRect(0, 0, width, height);
+
 					// Draw image
 					ctx.drawImage(img, 0, 0, width, height);
 


### PR DESCRIPTION
## Summary
- Fixes issue where transparent PNG images had transparent backgrounds after resizing
- Adds white background fill before drawing images on canvas to ensure consistent appearance

## Changes

### Image Resize Logic
- Modified `image_resize.js` to fill canvas with white color before drawing the image
- This prevents transparent backgrounds from showing through resized PNG images

## Test plan
- [x] Resize transparent PNG images and verify background is white instead of transparent
- [x] Confirm no visual regressions for non-transparent images
- [x] Manual testing in different browsers to ensure consistent rendering

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4bc5cc5f-9e93-4224-b6a2-8ee106177d24