### PR TITLE
Add PDF caching configuration to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,9 @@ S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_REGION=us-east-1
 S3_BUCKET=your-bucket-name
+
+# PDF Caching Configuration
+# Set to a date in YYYY-MM-DD format to enable PDF caching
+# Only completed inspections created after this date will be cached
+# Leave empty to disable caching
+PDF_CACHE_FROM=


### PR DESCRIPTION
## Summary
- Introduces PDF caching configuration in the environment example file
- Allows enabling PDF caching based on a date threshold
- Provides clear instructions for setting the cache start date or disabling caching

## Changes

### Configuration
- Updated `.env.example` to include new `PDF_CACHE_FROM` variable
- Added comments explaining the purpose and usage of the `PDF_CACHE_FROM` variable:
  - Format: YYYY-MM-DD
  - Caches only completed inspections created after the specified date
  - Leave empty to disable caching

## Test plan
- Verify `.env.example` includes the new PDF caching configuration
- Confirm documentation comments are clear and informative
- Ensure no impact on existing environment variables or functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f9a14204-b365-45e7-9563-b7b5f62099a3