### PR TITLE
Fix N+1 query in unit deletion by preloading attachments

### DIFF
--- a/app/services/seed_data_service.rb
+++ b/app/services/seed_data_service.rb
@@ -43,8 +43,8 @@ class SeedDataService
       ActiveRecord::Base.transaction do
         # Delete inspections first (due to foreign key constraints)
         user.inspections.seed_data.destroy_all
-        # Then delete units
-        user.units.seed_data.destroy_all
+        # Then delete units with preloaded attachments to avoid N+1
+        user.units.seed_data.includes(photo_attachment: :blob, cached_pdf_attachment: :blob).destroy_all
       end
       true
     end


### PR DESCRIPTION
## Summary
- Fixes an N+1 query issue when deleting units during seed data cleanup
- Preloads photo and cached PDF attachments to optimize database queries

## Changes

### SeedDataService
- Updated `user.units.seed_data.destroy_all` to include preloading of `photo_attachment` and `cached_pdf_attachment` blobs
- Ensures attachments are loaded in a single query before deletion to avoid N+1 queries

## Test plan
- [ ] Verify that seed data deletion still works correctly without errors
- [ ] Confirm that the number of database queries is reduced when deleting units with attachments
- [ ] Run existing tests to ensure no regressions in seed data handling

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9ab31dbe-fbe1-4f3e-8cee-0dcc102f9684