### PR TITLE
Restrict Sentry logging to production environment only

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,7 +7,7 @@ require "sentry-rails"
 
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
-  config.enabled_environments = %w[production development]
+  config.enabled_environments = %w[production]
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.send_default_pii = false
 


### PR DESCRIPTION
## Summary
- Updates Sentry configuration to enable logging exclusively in the production environment
- Removes development environment from Sentry's enabled environments list

## Changes

### Configuration
- Modified `config/initializers/sentry.rb`:
  - Changed `config.enabled_environments` from `["production", "development"]` to `["production"]`

## Rationale
- Limits Sentry error tracking and logging to production to reduce noise and irrelevant data from development

## Test plan
- Verify Sentry initializes only in production environment
- Confirm no Sentry logging occurs in development environment after this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/37bcdc72-4b2e-476a-ac01-8b3ba6766888