### PR TITLE
Add admin releases page fetching GitHub releases

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -71,14 +71,22 @@ class AdminController < ApplicationController
     docker_index = body.index("## Docker Images")
     processed_body = docker_index ? body[0...docker_index].strip : body
 
+    # Remove [Read the full changelog here] links
+    changelog_pattern = /\[Read the full changelog here\]\([^)]+\)/
+    processed_body = processed_body.gsub(changelog_pattern, "")
+    processed_body = processed_body.strip
+
     convert_markdown_to_html(processed_body)
   end
 
   def convert_markdown_to_html(text)
-    # Convert headers
-    html = text.gsub(/^### (.+)$/, '<h4>\1</h4>')
-    html = html.gsub(/^## (.+)$/, '<h3>\1</h3>')
-    html = html.gsub(/^# (.+)$/, '<h2>\1</h2>')
+    # Remove headers (they duplicate version info)
+    html = text.gsub(/^### .+$/, "")
+    html = html.gsub(/^## .+$/, "")
+    html = html.gsub(/^# .+$/, "")
+
+    # Clean up extra newlines from removed headers
+    html = html.gsub(/\n{3,}/, "\n\n").strip
 
     # Convert bold and bullet points
     html = html.gsub(/\*\*(.+?)\*\*/, '<strong>\1</strong>')

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -48,7 +48,7 @@ class AdminController < ApplicationController
         {
           name: release["name"],
           tag_name: release["tag_name"],
-          published_at: Time.parse(release["published_at"]),
+          published_at: Time.zone.parse(release["published_at"]),
           body: release["body"],
           html_url: release["html_url"],
           author: release["author"]["login"]

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,4 +6,58 @@ class AdminController < ApplicationController
   def index
     @show_backups = ENV["USE_S3_STORAGE"] == "true"
   end
+
+  def releases
+    @releases = Rails.cache.fetch("github_releases", expires_in: 1.hour) do
+      fetch_github_releases
+    end
+  rescue => e
+    Rails.logger.error "Failed to fetch GitHub releases: #{e.message}"
+    @releases = []
+    flash.now[:error] = t("admin.releases.fetch_error")
+  end
+
+  private
+
+  def fetch_github_releases
+    response = make_github_api_request
+    parse_github_response(response)
+  end
+
+  def make_github_api_request
+    require "net/http"
+
+    uri = URI("https://api.github.com/repos/chobbledotcom/play-test/releases")
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    http.read_timeout = 10
+
+    request = Net::HTTP::Get.new(uri)
+    request["Accept"] = "application/vnd.github.v3+json"
+    request["User-Agent"] = "PlayTest-Admin"
+
+    http.request(request)
+  end
+
+  def parse_github_response(response)
+    require "json"
+
+    if response.code == "200"
+      JSON.parse(response.body).map do |release|
+        {
+          name: release["name"],
+          tag_name: release["tag_name"],
+          published_at: Time.parse(release["published_at"]),
+          body: release["body"],
+          html_url: release["html_url"],
+          author: release["author"]["login"]
+        }
+      end
+    else
+      log_msg = "GitHub API returned #{response.code}: #{response.body}"
+      Rails.logger.error log_msg
+      []
+    end
+  end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -44,20 +44,63 @@ class AdminController < ApplicationController
     require "json"
 
     if response.code == "200"
-      JSON.parse(response.body).map do |release|
-        {
-          name: release["name"],
-          tag_name: release["tag_name"],
-          published_at: Time.zone.parse(release["published_at"]),
-          body: release["body"],
-          html_url: release["html_url"],
-          author: release["author"]["login"]
-        }
-      end
+      JSON.parse(response.body).map { |release| format_release(release) }
     else
       log_msg = "GitHub API returned #{response.code}: #{response.body}"
       Rails.logger.error log_msg
       []
     end
+  end
+
+  def format_release(release)
+    {
+      name: release["name"],
+      tag_name: release["tag_name"],
+      published_at: Time.zone.parse(release["published_at"]),
+      body: process_release_body(release["body"]),
+      html_url: release["html_url"],
+      author: release["author"]["login"],
+      is_bot: release["author"]["login"].include?("[bot]")
+    }
+  end
+
+  def process_release_body(body)
+    return nil if body.blank?
+
+    # Find the position of "## Docker Images" and truncate
+    docker_index = body.index("## Docker Images")
+    processed_body = docker_index ? body[0...docker_index].strip : body
+
+    convert_markdown_to_html(processed_body)
+  end
+
+  def convert_markdown_to_html(text)
+    # Convert headers
+    html = text.gsub(/^### (.+)$/, '<h4>\1</h4>')
+    html = html.gsub(/^## (.+)$/, '<h3>\1</h3>')
+    html = html.gsub(/^# (.+)$/, '<h2>\1</h2>')
+
+    # Convert bold and bullet points
+    html = html.gsub(/\*\*(.+?)\*\*/, '<strong>\1</strong>')
+    html = convert_bullet_points(html)
+
+    # Convert line breaks to paragraphs
+    wrap_paragraphs(html)
+  end
+
+  def convert_bullet_points(text)
+    html = text.gsub(/^- (.+)$/, '<li>\1</li>')
+    html.gsub(/(<li>.*<\/li>)/m) { |match| "<ul>#{match}</ul>" }
+  end
+
+  def wrap_paragraphs(text)
+    text.split("\n\n").map do |paragraph|
+      next if paragraph.strip.empty?
+      if paragraph.include?("<h") || paragraph.include?("<ul>")
+        paragraph
+      else
+        "<p>#{paragraph}</p>"
+      end
+    end.compact.join("\n")
   end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -8,6 +8,7 @@
     <li><%= link_to t("inspector_companies.titles.index"), inspector_companies_path %></li>
     <li><%= link_to t("navigation.pages"), pages_path %></li>
     <li><%= link_to t("navigation.jobs"), "/mission_control" %></li>
+    <li><%= link_to t("navigation.releases"), admin_releases_path %></li>
     <% if @show_backups %>
       <li><%= link_to t("navigation.backups"), backups_path %></li>
     <% end %>

--- a/app/views/admin/releases.html.erb
+++ b/app/views/admin/releases.html.erb
@@ -15,17 +15,25 @@
           <h2>
             <%= link_to release[:name] || release[:tag_name], release[:html_url], target: "_blank", rel: "noopener" %>
           </h2>
-          <p>
-            <%= t("admin.releases.published_by", author: release[:author]) %>
-            <time datetime="<%= release[:published_at].iso8601 %>">
-              <%= l(release[:published_at], format: :long) %>
-            </time>
-          </p>
+          <% unless release[:is_bot] %>
+            <p>
+              <%= t("admin.releases.published_by", author: release[:author]) %>
+              <time datetime="<%= release[:published_at].iso8601 %>">
+                <%= l(release[:published_at], format: :long) %>
+              </time>
+            </p>
+          <% else %>
+            <p>
+              <time datetime="<%= release[:published_at].iso8601 %>">
+                <%= l(release[:published_at], format: :long) %>
+              </time>
+            </p>
+          <% end %>
         </header>
         
         <% if release[:body].present? %>
           <div>
-            <%= simple_format(release[:body]) %>
+            <%= release[:body].html_safe %>
           </div>
         <% end %>
       </article>

--- a/app/views/admin/releases.html.erb
+++ b/app/views/admin/releases.html.erb
@@ -1,0 +1,34 @@
+<header>
+  <h1><%= t("admin.releases.title") %></h1>
+  <nav>
+    <%= link_to t("admin.back_to_admin"), admin_path %>
+  </nav>
+</header>
+
+<main>
+  <% if @releases.empty? %>
+    <p><%= t("admin.releases.no_releases") %></p>
+  <% else %>
+    <% @releases.each do |release| %>
+      <article>
+        <header>
+          <h2>
+            <%= link_to release[:name] || release[:tag_name], release[:html_url], target: "_blank", rel: "noopener" %>
+          </h2>
+          <p>
+            <%= t("admin.releases.published_by", author: release[:author]) %>
+            <time datetime="<%= release[:published_at].iso8601 %>">
+              <%= l(release[:published_at], format: :long) %>
+            </time>
+          </p>
+        </header>
+        
+        <% if release[:body].present? %>
+          <div>
+            <%= simple_format(release[:body]) %>
+          </div>
+        <% end %>
+      </article>
+    <% end %>
+  <% end %>
+</main>

--- a/config/locales/admin.en.yml
+++ b/config/locales/admin.en.yml
@@ -2,3 +2,8 @@ en:
   admin:
     title: "Admin Dashboard"
     back_to_admin: "Back to Admin"
+    releases:
+      title: "GitHub Releases"
+      no_releases: "No releases found."
+      published_by: "Published by %{author} on"
+      fetch_error: "Failed to fetch releases from GitHub. Please try again later."

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -13,6 +13,7 @@ en:
     jobs: "Jobs"
     admin: "Admin"
     backups: "Backups"
+    releases: "Releases"
 
   # Shared UI elements
   shared:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
 
   # Admin
   get "admin", to: "admin#index"
+  get "admin/releases", to: "admin#releases", as: :admin_releases
 
   # Backups
   resources :backups, only: [:index] do

--- a/spec/features/admin/admin_navigation_spec.rb
+++ b/spec/features/admin/admin_navigation_spec.rb
@@ -32,13 +32,15 @@ RSpec.feature "Admin Navigation", type: :feature do
     expect(page).to have_link(I18n.t("inspector_companies.titles.index"))
     expect(page).to have_link(I18n.t("navigation.pages"))
     expect(page).to have_link(I18n.t("navigation.jobs"))
+    expect(page).to have_link(I18n.t("navigation.releases"))
   end
 
   scenario "regular user cannot access admin path" do
     sign_in(regular_user)
     visit admin_path
 
-    expect(page).to have_content(I18n.t("forms.session_new.status.admin_required"))
+    admin_required_msg = I18n.t("forms.session_new.status.admin_required")
+    expect(page).to have_content(admin_required_msg)
     expect(current_path).to eq(root_path)
   end
 

--- a/spec/features/admin/admin_releases_changelog_link_spec.rb
+++ b/spec/features/admin/admin_releases_changelog_link_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.feature "Admin Releases Changelog Link", type: :feature do
+  let(:admin_user) { create(:user, :admin, :without_company) }
+
+  scenario "removes [Read the full changelog here] links from release body" do
+    # Mock the raw API response with changelog link
+    changelog_link = "[Read the full changelog here]" \
+                     "(https://example.com/changelog)"
+    release_body = "## Changes\n\nNew features added\n\n" \
+                   "#{changelog_link}\n\n" \
+                   "## More Info\n\nAdditional details"
+
+    mock_response = double("response", code: "200", body: JSON.generate([
+      {
+        "name" => "Version 3.0.0",
+        "tag_name" => "v3.0.0",
+        "published_at" => 1.day.ago.iso8601,
+        "body" => release_body,
+        "html_url" => "https://github.com/chobbledotcom/play-test/" \
+                      "releases/v3.0.0",
+        "author" => {"login" => "developer1"}
+      }
+    ]))
+
+    allow(Rails.cache).to receive(:fetch).and_yield
+    allow_any_instance_of(AdminController).to receive(:make_github_api_request)
+      .and_return(mock_response)
+
+    sign_in(admin_user)
+    visit admin_releases_path
+
+    # Headers are removed, so we don't see "Changes" or "More Info"
+    expect(page).not_to have_content("Changes")
+    expect(page).not_to have_content("More Info")
+
+    # But the content should be there
+    expect(page).to have_content("New features added")
+    expect(page).to have_content("Additional details")
+
+    # Should NOT have the changelog link
+    expect(page).not_to have_content("Read the full changelog here")
+    expect(page).not_to have_link("Read the full changelog here")
+  end
+end

--- a/spec/features/admin/admin_releases_docker_test_spec.rb
+++ b/spec/features/admin/admin_releases_docker_test_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Admin Releases Docker Section", type: :feature do
+  let(:admin_user) { create(:user, :admin, :without_company) }
+
+  scenario "hides Docker Images section from release body" do
+    # Mock the raw API response
+    release_body = "## Changes\n\nNew features\n\n" \
+                   "## Docker Images\n\nDocker info here"
+    release_url = "https://github.com/chobbledotcom/play-test/releases/v2.0.0"
+
+    mock_response = double("response", code: "200", body: JSON.generate([
+      {
+        "name" => "Version 2.0.0",
+        "tag_name" => "v2.0.0",
+        "published_at" => 1.day.ago.iso8601,
+        "body" => release_body,
+        "html_url" => release_url,
+        "author" => {"login" => "developer1"}
+      }
+    ]))
+
+    allow(Rails.cache).to receive(:fetch).and_yield
+    allow_any_instance_of(AdminController).to receive(:make_github_api_request)
+      .and_return(mock_response)
+
+    sign_in(admin_user)
+    visit admin_releases_path
+
+    expect(page).to have_content("Changes")
+    expect(page).to have_content("New features")
+    expect(page).not_to have_content("Docker Images")
+    expect(page).not_to have_content("Docker info here")
+  end
+end

--- a/spec/features/admin/admin_releases_docker_test_spec.rb
+++ b/spec/features/admin/admin_releases_docker_test_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Admin Releases Docker Section", type: :feature do
 
   scenario "hides Docker Images section from release body" do
     # Mock the raw API response
-    release_body = "## Changes\n\nNew features\n\n" \
+    release_body = "## Changes\n\n- New features added\n- Bug fixes\n\n" \
                    "## Docker Images\n\nDocker info here"
     release_url = "https://github.com/chobbledotcom/play-test/releases/v2.0.0"
 
@@ -27,8 +27,10 @@ RSpec.feature "Admin Releases Docker Section", type: :feature do
     sign_in(admin_user)
     visit admin_releases_path
 
-    expect(page).to have_content("Changes")
-    expect(page).to have_content("New features")
+    # Headers are stripped, so we shouldn't see "Changes"
+    expect(page).not_to have_content("Changes")
+    expect(page).to have_content("New features added")
+    expect(page).to have_content("Bug fixes")
     expect(page).not_to have_content("Docker Images")
     expect(page).not_to have_content("Docker info here")
   end

--- a/spec/features/admin/admin_releases_spec.rb
+++ b/spec/features/admin/admin_releases_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.feature "Admin Releases", type: :feature do
+  let(:admin_user) { create(:user, :admin, :without_company) }
+  let(:regular_user) { create(:user, :active_user) }
+
+  let(:sample_releases) do
+    [
+      {
+        name: "Version 1.2.0",
+        tag_name: "v1.2.0",
+        published_at: 2.days.ago,
+        body: "## Changes\n- New feature X\n- Bug fix Y",
+        html_url: "https://github.com/chobbledotcom/play-test/releases/v1.2.0",
+        author: "developer1"
+      },
+      {
+        name: "Version 1.1.0",
+        tag_name: "v1.1.0",
+        published_at: 1.week.ago,
+        body: "Initial release",
+        html_url: "https://github.com/chobbledotcom/play-test/releases/v1.1.0",
+        author: "developer2"
+      }
+    ]
+  end
+
+  before do
+    allow(Rails.cache).to receive(:fetch).and_yield
+    allow_any_instance_of(AdminController).to receive(:fetch_github_releases)
+      .and_return(sample_releases)
+  end
+
+  scenario "admin can view releases page" do
+    sign_in(admin_user)
+    visit admin_path
+
+    click_link I18n.t("navigation.releases")
+
+    expect(page).to have_content(I18n.t("admin.releases.title"))
+    expect(page).to have_link(I18n.t("admin.back_to_admin"))
+
+    # Check first release
+    first_release_url = sample_releases[0][:html_url]
+    expect(page).to have_link("Version 1.2.0", href: first_release_url)
+    expect(page).to have_content("developer1")
+    expect(page).to have_content("New feature X")
+    expect(page).to have_content("Bug fix Y")
+
+    # Check second release
+    second_release_url = sample_releases[1][:html_url]
+    expect(page).to have_link("Version 1.1.0", href: second_release_url)
+    expect(page).to have_content("developer2")
+    expect(page).to have_content("Initial release")
+  end
+
+  scenario "regular user cannot access releases page" do
+    sign_in(regular_user)
+    visit admin_releases_path
+
+    admin_required_msg = I18n.t("forms.session_new.status.admin_required")
+    expect(page).to have_content(admin_required_msg)
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario "shows message when no releases are found" do
+    allow_any_instance_of(AdminController).to receive(:fetch_github_releases)
+      .and_return([])
+
+    sign_in(admin_user)
+    visit admin_releases_path
+
+    expect(page).to have_content(I18n.t("admin.releases.no_releases"))
+  end
+
+  scenario "shows error message when fetching fails" do
+    allow(Rails.cache).to receive(:fetch).and_raise(StandardError, "API Error")
+
+    sign_in(admin_user)
+    visit admin_releases_path
+
+    expect(page).to have_content(I18n.t("admin.releases.fetch_error"))
+  end
+
+  scenario "uses caching for releases data" do
+    expect(Rails.cache).to receive(:fetch)
+      .with("github_releases", expires_in: 1.hour)
+      .and_yield
+
+    sign_in(admin_user)
+    visit admin_releases_path
+  end
+end

--- a/spec/features/admin/admin_releases_spec.rb
+++ b/spec/features/admin/admin_releases_spec.rb
@@ -10,17 +10,20 @@ RSpec.feature "Admin Releases", type: :feature do
         name: "Version 1.2.0",
         tag_name: "v1.2.0",
         published_at: 2.days.ago,
-        body: "## Changes\n- New feature X\n- Bug fix Y",
+        body: "<h3>Changes</h3>\n<ul><li>New feature X</li>\n" \
+              "<li>Bug fix Y</li></ul>",
         html_url: "https://github.com/chobbledotcom/play-test/releases/v1.2.0",
-        author: "developer1"
+        author: "developer1",
+        is_bot: false
       },
       {
         name: "Version 1.1.0",
         tag_name: "v1.1.0",
         published_at: 1.week.ago,
-        body: "Initial release",
+        body: "<p>Initial release</p>",
         html_url: "https://github.com/chobbledotcom/play-test/releases/v1.1.0",
-        author: "developer2"
+        author: "github-actions[bot]",
+        is_bot: true
       }
     ]
   end
@@ -47,10 +50,10 @@ RSpec.feature "Admin Releases", type: :feature do
     expect(page).to have_content("New feature X")
     expect(page).to have_content("Bug fix Y")
 
-    # Check second release
+    # Check second release (bot author)
     second_release_url = sample_releases[1][:html_url]
     expect(page).to have_link("Version 1.1.0", href: second_release_url)
-    expect(page).to have_content("developer2")
+    expect(page).not_to have_content("github-actions[bot]")
     expect(page).to have_content("Initial release")
   end
 

--- a/spec/features/admin/admin_releases_spec.rb
+++ b/spec/features/admin/admin_releases_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Admin Releases", type: :feature do
         name: "Version 1.2.0",
         tag_name: "v1.2.0",
         published_at: 2.days.ago,
-        body: "<h3>Changes</h3>\n<ul><li>New feature X</li>\n" \
-              "<li>Bug fix Y</li></ul>",
+        body: "<ul><li>New feature X</li>\n<li>Bug fix Y</li></ul>",
         html_url: "https://github.com/chobbledotcom/play-test/releases/v1.2.0",
         author: "developer1",
         is_bot: false


### PR DESCRIPTION
## Summary
- Adds a new admin page to display GitHub releases for the repository
- Fetches releases from GitHub API with caching for 1 hour
- Handles API errors gracefully with error logging and user flash messages
- Adds navigation link to releases page in admin dashboard
- Implements feature specs covering admin access, release display, error handling, and caching

## Changes

### Backend
- Added `releases` action in `AdminController` to fetch and parse GitHub releases
- Uses `Net::HTTP` to call GitHub API and parse JSON response
- Caches releases data in Rails cache for 1 hour
- Logs errors and shows flash error message on failure

### Frontend
- Created `admin/releases.html.erb` view to list releases with name, author, published date, and body
- Added link to releases page in admin index navigation

### Localization
- Added English translations for releases page titles, messages, and navigation link

### Routing
- Added route `admin/releases` mapped to `admin#releases`

### Testing
- Added comprehensive feature specs for admin releases page:
  - Admin user can view releases
  - Regular user is denied access
  - Shows message when no releases found
  - Shows error message on fetch failure
  - Verifies caching behavior

## Test plan
- [x] Admin user can navigate to releases page and see release details
- [x] Regular user cannot access releases page
- [x] Releases page shows appropriate messages when no releases or errors occur
- [x] Caching is used to avoid repeated API calls
- [x] Navigation link to releases page appears in admin dashboard

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/c6332533-9196-427c-901e-8d3e1625507c