### PR TITLE
Restrict PDF debug info visibility to development environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
@@ -89,7 +90,7 @@ class ApplicationController < ActionController::Base
   end
 
   def admin_debug_enabled?
-    Rails.env.development? || current_user&.admin? || impersonating?
+    Rails.env.development?
   end
 
   def seed_data_action?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,16 +1,18 @@
+# typed: false
+
 require "rails_helper"
 
 RSpec.describe ApplicationController, type: :controller do
   # Create anonymous controller for testing
   controller do
     # Public action for testing filters
-    def index
+    define_method(:index) do
       render plain: "OK"
     end
 
     # Action that skips login requirement
     skip_before_action :require_login, only: :public_action
-    def public_action
+    define_method(:public_action) do
       render plain: "Public"
     end
   end
@@ -202,7 +204,7 @@ RSpec.describe ApplicationController, type: :controller do
         skip_before_action :require_login
         before_action :require_logged_out
 
-        def index
+        define_method(:index) do
           render plain: "OK"
         end
       end
@@ -237,7 +239,7 @@ RSpec.describe ApplicationController, type: :controller do
         skip_before_action :require_login
         before_action :require_admin
 
-        def index
+        define_method(:index) do
           render plain: "OK"
         end
       end
@@ -310,16 +312,16 @@ RSpec.describe ApplicationController, type: :controller do
         expect(controller.send(:admin_debug_enabled?)).to be true
       end
 
-      it "returns true for admin users" do
+      it "returns false for admin users in production" do
         allow(Rails.env).to receive(:development?).and_return(false)
         allow(controller).to receive(:current_user).and_return(admin)
-        expect(controller.send(:admin_debug_enabled?)).to be true
+        expect(controller.send(:admin_debug_enabled?)).to be false
       end
 
-      it "returns true when impersonating" do
+      it "returns false when impersonating in production" do
         allow(Rails.env).to receive(:development?).and_return(false)
         session[:original_admin_id] = 123
-        expect(controller.send(:admin_debug_enabled?)).to be true
+        expect(controller.send(:admin_debug_enabled?)).to be false
       end
 
       it "returns false for regular users in production" do
@@ -347,7 +349,7 @@ RSpec.describe ApplicationController, type: :controller do
     controller do
       skip_before_action :require_login
 
-      def index
+      define_method(:index) do
         raise StandardError, "Test error"
       end
     end

--- a/spec/requests/exports/pdf_debug_info_spec.rb
+++ b/spec/requests/exports/pdf_debug_info_spec.rb
@@ -1,36 +1,88 @@
+# typed: false
+
 require "rails_helper"
 require "pdf/inspector"
 
-RSpec.describe "PDF Debug Info for Impersonation", type: :request do
+RSpec.describe "PDF Debug Info", type: :request do
   let(:admin_user) { create(:user, :admin) }
   let(:regular_user) { create(:user) }
   let(:unit) { create(:unit, user: regular_user) }
   let(:inspection) { create(:inspection, :completed, user: regular_user, unit: unit) }
 
-  describe "impersonation shows debug info" do
-    it "admin impersonating user sees debug info in PDF" do
-      # Login as admin
-      login_as(admin_user)
+  describe "debug info visibility" do
+    context "in production mode" do
+      before do
+        allow(Rails.env).to receive(:development?).and_return(false)
+      end
 
-      # Impersonate regular user
-      post impersonate_user_path(regular_user)
+      it "admin does not see debug info in PDF" do
+        login_as(admin_user)
 
-      # Verify impersonation is active
-      expect(session[:original_admin_id]).to eq(admin_user.id)
-      expect(session[:user_id]).to eq(regular_user.id)
+        # Create unit and inspection for admin
+        admin_unit = create(:unit, user: admin_user)
+        admin_inspection = create(:inspection, :completed, user: admin_user, unit: admin_unit)
 
-      # Get the PDF
-      get "/inspections/#{inspection.id}.pdf"
+        # Get the PDF
+        get "/inspections/#{admin_inspection.id}.pdf"
 
-      expect(response).to have_http_status(:success)
-      expect(response.content_type).to eq("application/pdf")
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/pdf")
 
-      # Extract PDF text
-      pdf_text = PDF::Inspector::Text.analyze(response.body).strings.join(" ")
+        # Extract PDF text
+        pdf_text = PDF::Inspector::Text.analyze(response.body).strings.join(" ")
 
-      # Should include debug info when impersonating
-      expect(pdf_text).to include(I18n.t("debug.title"))
-      expect(pdf_text).to include(I18n.t("debug.query_count"))
+        # Should NOT include debug info for admin in production
+        expect(pdf_text).not_to include(I18n.t("debug.title"))
+        expect(pdf_text).not_to include(I18n.t("debug.query_count"))
+      end
+
+      it "admin impersonating user does not see debug info in PDF" do
+        # Login as admin
+        login_as(admin_user)
+
+        # Impersonate regular user
+        post impersonate_user_path(regular_user)
+
+        # Verify impersonation is active
+        expect(session[:original_admin_id]).to eq(admin_user.id)
+        expect(session[:user_id]).to eq(regular_user.id)
+
+        # Get the PDF
+        get "/inspections/#{inspection.id}.pdf"
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/pdf")
+
+        # Extract PDF text
+        pdf_text = PDF::Inspector::Text.analyze(response.body).strings.join(" ")
+
+        # Should NOT include debug info when impersonating in production
+        expect(pdf_text).not_to include(I18n.t("debug.title"))
+        expect(pdf_text).not_to include(I18n.t("debug.query_count"))
+      end
+    end
+
+    context "in development mode" do
+      before do
+        allow(Rails.env).to receive(:development?).and_return(true)
+      end
+
+      it "shows debug info in PDF" do
+        login_as(regular_user)
+
+        # Get the PDF
+        get "/inspections/#{inspection.id}.pdf"
+
+        expect(response).to have_http_status(:success)
+        expect(response.content_type).to eq("application/pdf")
+
+        # Extract PDF text
+        pdf_text = PDF::Inspector::Text.analyze(response.body).strings.join(" ")
+
+        # Should include debug info in development
+        expect(pdf_text).to include(I18n.t("debug.title"))
+        expect(pdf_text).to include(I18n.t("debug.query_count"))
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Restricts the visibility of debug information in PDFs to the development environment only
- Removes debug info visibility for admin users and impersonators in production
- Updates related controller logic and tests to reflect this behavior

## Changes

### ApplicationController
- Modified `admin_debug_enabled?` method to return true only in development environment

### Tests
- Updated `application_controller_spec.rb` to test that admin debug is disabled for admin users and impersonators in production
- Refactored `pdf_debug_info_spec.rb` to:
  - Verify debug info is not included in PDFs for admin users or impersonators in production
  - Confirm debug info is included in development environment

## Test plan
- [x] Run controller specs to verify `admin_debug_enabled?` behavior
- [x] Run request specs to confirm PDF debug info visibility matches environment
- [x] Manual verification of PDF content in development and production modes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/325d852a-3508-4b88-ada5-af2adec548c1