### PR TITLE
Add SCSS support with expanded style and RSpec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
+/vendor/bundle
 
 # Ignore all environment files (except templates).
 /.env*

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ source "https://rubygems.org"
 gem "rails", "~> 8.0.2"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
+# SCSS/Sass support for Rails [https://github.com/rails/sass-rails]
+gem "sass-rails", "~> 6.0"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", ">= 1.4"
 # Use the Puma web server [https://github.com/puma/puma]

--- a/app/assets/stylesheets/about.scss
+++ b/app/assets/stylesheets/about.scss
@@ -1,0 +1,22 @@
+/* About page specific styles */
+#about {
+  article {
+    max-width: 60rem;
+    margin: 0 auto;
+    text-align: left;
+  }
+
+  p {
+    text-align: left;
+    line-height: 1.6;
+  }
+
+  table {
+    text-align: left;
+  }
+
+  th,
+  td {
+    text-align: left;
+  }
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,10 @@ module PlayTest
     # Don't generate system test files.
     config.generators.system_tests = nil
 
+    # Configure Sass/SCSS compilation to use expanded style
+    config.sass.preferred_syntax = :scss
+    config.sass.style = :expanded
+
     # Preserve full timezone rather than offset in Rails 8.1+
     config.active_support.to_time_preserves_timezone = :zone
 

--- a/spec/lib/about_scss_compilation_spec.rb
+++ b/spec/lib/about_scss_compilation_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "About SCSS Compilation" do
+  describe "about.scss compilation" do
+    it "compiles about.scss to match the original about.css structure" do
+      # Read the SCSS file
+      scss_path = Rails.root.join("app/assets/stylesheets/about.scss")
+      scss_content = File.read(scss_path)
+
+      # Expected CSS output (based on the original about.css)
+      expected_css = <<~CSS
+        /* About page specific styles */
+        #about article {
+          max-width: 60rem;
+          margin: 0 auto;
+          text-align: left;
+        }
+        
+        #about p {
+          text-align: left;
+          line-height: 1.6;
+        }
+        
+        #about table {
+          text-align: left;
+        }
+        
+        #about th,
+        #about td {
+          text-align: left;
+        }
+      CSS
+
+      # Try to compile the SCSS using SassC if available
+      begin
+        require "sassc"
+        engine = SassC::Engine.new(scss_content, style: :expanded)
+        compiled_css = engine.render
+
+        # Normalize whitespace for comparison
+        # Remove extra spaces, normalize line endings
+        normalize = ->(str) {
+          str.strip
+            .gsub(/\/\*.*?\*\//m, "") # Remove comments for comparison
+            .gsub(/\s+/, " ")
+            .gsub(/\s*{\s*/, " { ")
+            .gsub(/\s*}\s*/, " } ")
+            .gsub(/\s*;\s*/, "; ")
+            .gsub(/}\s*/, "}\n")
+            .strip
+        }
+
+        normalized_compiled = normalize.call(compiled_css)
+        normalized_expected = normalize.call(expected_css)
+
+        # Check that all the selectors are present
+        expect(normalized_compiled).to include("#about article")
+        expect(normalized_compiled).to include("#about p")
+        expect(normalized_compiled).to include("#about table")
+        expect(normalized_compiled).to include("#about th")
+        expect(normalized_compiled).to include("#about td")
+
+        # Check that the properties are present
+        expect(normalized_compiled).to include("max-width: 60rem")
+        expect(normalized_compiled).to include("margin: 0 auto")
+        expect(normalized_compiled).to include("text-align: left")
+        expect(normalized_compiled).to include("line-height: 1.6")
+      rescue LoadError
+        skip "SassC gem not available, skipping compilation test"
+      end
+    end
+
+    it "produces functionally equivalent CSS from nested SCSS" do
+      scss_content = <<~SCSS
+        #about {
+          article {
+            max-width: 60rem;
+            margin: 0 auto;
+            text-align: left;
+          }
+
+          p {
+            text-align: left;
+            line-height: 1.6;
+          }
+
+          table {
+            text-align: left;
+          }
+
+          th,
+          td {
+            text-align: left;
+          }
+        }
+      SCSS
+
+      begin
+        require "sassc"
+        engine = SassC::Engine.new(scss_content, style: :expanded)
+        compiled = engine.render
+
+        # Verify the compiled output contains all expected rules
+        expect(compiled).to match(/#about article\s*{[^}]*max-width:\s*60rem/)
+        expect(compiled).to match(/#about article\s*{[^}]*margin:\s*0 auto/)
+        expect(compiled).to match(/#about p\s*{[^}]*line-height:\s*1\.6/)
+        expect(compiled).to match(/#about table\s*{[^}]*text-align:\s*left/)
+        expect(compiled).to match(/#about th,\s*#about td\s*{[^}]*text-align:\s*left/)
+      rescue LoadError
+        skip "SassC gem not available, skipping compilation test"
+      end
+    end
+  end
+end

--- a/spec/lib/scss_compilation_spec.rb
+++ b/spec/lib/scss_compilation_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "SCSS Compilation" do
+  describe "nested SCSS compilation" do
+    it "compiles nested SCSS to expanded CSS format" do
+      # Create a temporary SCSS string with nested rules
+      scss_content = <<~SCSS
+        .container {
+          width: 100%;
+          padding: 20px;
+          
+          .header {
+            background-color: #333;
+            color: white;
+            
+            h1 {
+              margin: 0;
+              font-size: 24px;
+            }
+            
+            nav {
+              ul {
+                list-style: none;
+                padding: 0;
+                
+                li {
+                  display: inline-block;
+                  margin-right: 10px;
+                  
+                  a {
+                    color: #fff;
+                    text-decoration: none;
+                    
+                    &:hover {
+                      text-decoration: underline;
+                    }
+                  }
+                }
+              }
+            }
+          }
+          
+          .content {
+            padding: 20px;
+            
+            p {
+              line-height: 1.6;
+            }
+          }
+        }
+      SCSS
+
+      # Expected expanded CSS output
+      expected_css = <<~CSS
+        .container {
+          width: 100%;
+          padding: 20px;
+        }
+        .container .header {
+          background-color: #333;
+          color: white;
+        }
+        .container .header h1 {
+          margin: 0;
+          font-size: 24px;
+        }
+        .container .header nav ul {
+          list-style: none;
+          padding: 0;
+        }
+        .container .header nav ul li {
+          display: inline-block;
+          margin-right: 10px;
+        }
+        .container .header nav ul li a {
+          color: #fff;
+          text-decoration: none;
+        }
+        .container .header nav ul li a:hover {
+          text-decoration: underline;
+        }
+        .container .content {
+          padding: 20px;
+        }
+        .container .content p {
+          line-height: 1.6;
+        }
+      CSS
+
+      # Use SassC to compile the SCSS
+      require "sassc"
+      engine = SassC::Engine.new(scss_content, style: :expanded)
+      compiled_css = engine.render
+
+      # Normalize whitespace for comparison
+      normalized_compiled = compiled_css.strip.gsub(/\s+/, " ").gsub(/;\s*}/, "; }").gsub(/{\s*/, "{ ").gsub(/;\s*/, "; ")
+      normalized_expected = expected_css.strip.gsub(/\s+/, " ").gsub(/;\s*}/, "; }").gsub(/{\s*/, "{ ").gsub(/;\s*/, "; ")
+
+      expect(normalized_compiled).to eq(normalized_expected)
+    end
+
+    it "verifies that sass-rails is configured with expanded style" do
+      # Check Rails configuration
+      expect(Rails.application.config.sass.style).to eq(:expanded)
+      expect(Rails.application.config.sass.preferred_syntax).to eq(:scss)
+    end
+
+    it "compiles SCSS variables correctly" do
+      scss_with_variables = <<~SCSS
+        $primary-color: #007bff;
+        $padding-base: 15px;
+        
+        .button {
+          background-color: $primary-color;
+          padding: $padding-base;
+          
+          &.large {
+            padding: $padding-base * 2;
+          }
+        }
+      SCSS
+
+      expected = <<~CSS
+        .button {
+          background-color: #007bff;
+          padding: 15px;
+        }
+        .button.large {
+          padding: 30px;
+        }
+      CSS
+
+      require "sassc"
+      engine = SassC::Engine.new(scss_with_variables, style: :expanded)
+      compiled = engine.render
+
+      # Normalize for comparison
+      normalized_compiled = compiled.strip.gsub(/\s+/, " ").gsub(/;\s*}/, "; }").gsub(/{\s*/, "{ ").gsub(/;\s*/, "; ")
+      normalized_expected = expected.strip.gsub(/\s+/, " ").gsub(/;\s*}/, "; }").gsub(/{\s*/, "{ ").gsub(/;\s*/, "; ")
+
+      expect(normalized_compiled).to eq(normalized_expected)
+    end
+
+    it "compiles SCSS mixins correctly" do
+      scss_with_mixins = <<~SCSS
+        @mixin border-radius($radius) {
+          border-radius: $radius;
+        }
+        
+        .card {
+          @include border-radius(8px);
+          padding: 20px;
+        }
+      SCSS
+
+      expected = <<~CSS
+        .card {
+          border-radius: 8px;
+          padding: 20px;
+        }
+      CSS
+
+      require "sassc"
+      engine = SassC::Engine.new(scss_with_mixins, style: :expanded)
+      compiled = engine.render
+
+      # Normalize for comparison
+      normalized_compiled = compiled.strip.gsub(/\s+/, " ").gsub(/;\s*}/, "; }").gsub(/{\s*/, "{ ").gsub(/;\s*/, "; ")
+      normalized_expected = expected.strip.gsub(/\s+/, " ").gsub(/;\s*}/, "; }").gsub(/{\s*/, "{ ").gsub(/;\s*/, "; ")
+
+      expect(normalized_compiled).to eq(normalized_expected)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds SCSS support to the Rails application using the `sass-rails` gem
- Configures SCSS compilation with expanded style and preferred syntax set to SCSS
- Introduces a new SCSS stylesheet for the About page
- Implements comprehensive RSpec tests to verify SCSS compilation and output correctness

## Changes

### Core Functionality
- Added `sass-rails` gem to Gemfile for SCSS support
- Configured SCSS compilation style and syntax in `config/application.rb`
- Created `app/assets/stylesheets/about.scss` with styles for the About page

### Testing
- Added `spec/lib/about_scss_compilation_spec.rb` to test compilation of `about.scss` and verify CSS output matches expected structure
- Added `spec/lib/scss_compilation_spec.rb` with multiple tests covering:
  - Nested SCSS compilation to expanded CSS
  - Verification of Rails SCSS configuration
  - Compilation of SCSS variables and mixins

### Miscellaneous
- Updated `.gitignore` to ignore `/vendor/bundle`

## Test plan
- Run RSpec to ensure all SCSS compilation tests pass
- Confirm SCSS files compile correctly to expanded CSS format
- Verify that the About page styles are correctly applied and match expected CSS output
- Ensure Rails configuration for SCSS is correctly set and tested

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7a07a540-c7f6-4d12-8215-a4d78b0c8cbd