### PR TITLE
Add sassc installation to Dockerfile and terragon-setup.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 sqlite3 libvips libyaml-dev && \
+    apt-get install --no-install-recommends -y curl libjemalloc2 sqlite3 libvips libyaml-dev sassc && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install supercronic for non-root cron support

--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Installing Ruby and dependencies..."
 sudo apt-get update -qq
-sudo apt-get install -y ruby-full ruby-bundler build-essential libsqlite3-dev libyaml-dev libvips-dev cmake pkg-config
+sudo apt-get install -y ruby-full ruby-bundler build-essential libsqlite3-dev libyaml-dev libvips-dev cmake pkg-config sassc
 
 echo "Installing bundler gem..."
 sudo gem install bundler


### PR DESCRIPTION
## Summary
- Adds installation of `sassc` to the Dockerfile and terragon-setup.sh setup script
- Ensures `sassc` is available as a dependency for the Terragon environment setup

## Changes

### Dockerfile
- Updated apt-get install command to include `sassc` alongside other base packages

### terragon-setup.sh
- Added `sassc` to the list of packages installed via apt-get for Ruby and dependencies setup

## Test plan
- [ ] Build Docker image and verify `sassc` is installed
- [ ] Run terragon-setup.sh and confirm `sassc` installation completes without errors
- [ ] Validate that `sassc` is available in the environment after setup

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/528a722b-e445-4048-a062-78cea0fc6de9