### PR TITLE
Refactor search UI and logic to support unit and inspection types

### DIFF
--- a/app/javascript/search.js
+++ b/app/javascript/search.js
@@ -7,9 +7,13 @@ class FederationSearch {
   }
 
   init() {
-    // Find the form inside the search div
+    // Find the form inside the search div or use the homepage search form
     const searchDiv = document.getElementById("search");
     this.form = searchDiv ? searchDiv.querySelector("form") : null;
+    if (!this.form) {
+      this.form = document.getElementById("homepage-search");
+    }
+    
     this.resultsContainer = document.getElementById("search-results");
     this.resultsBody = document.getElementById("results-body");
 
@@ -24,7 +28,7 @@ class FederationSearch {
     const urlParams = new URLSearchParams(window.location.search);
     const id = urlParams.get("id");
     if (id) {
-      const idField = this.form.querySelector('input[name="search[id]"]');
+      const idField = this.form.querySelector('input[name="id"]');
       if (idField) {
         idField.value = id;
         this.performSearch();
@@ -34,8 +38,7 @@ class FederationSearch {
 
   performSearch() {
     const formData = new FormData(this.form);
-    const type = formData.get("search[type]");
-    const id = formData.get("search[id]").toUpperCase();
+    const id = formData.get("id").toUpperCase();
 
     // Show results container
     this.resultsContainer.style.display = "block";
@@ -50,9 +53,10 @@ class FederationSearch {
       actionCell.textContent = "-";
     });
 
-    // Check each site
+    // Check each site for both units and inspections
     rows.forEach((row) => {
       const siteUrl = row.dataset.siteUrl;
+      const type = row.dataset.type;
       this.checkSite(row, siteUrl, type, id);
     });
   }

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -9,30 +9,7 @@
 <%= @page.safe_content %>
 
 <% if @page.slug == "/" %>
-  <form action="/search" method="get" id="homepage-search">
-    <input
-      type="text"
-      name="id"
-      placeholder="<%= t('search.homepage.placeholder') %>"
-      pattern="[A-Za-z0-9]{8}"
-      maxlength="8"
-      required>
-    <button type="submit">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24">
-        <path
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="1.5"
-          d="m14 14l2.5 2.5m-.067 2.025a1.48 1.48 0 1 1 2.092-2.092l3.042 3.042a1.48 1.48 0 1 1-2.092 2.092zM16 9A7 7 0 1 0 2 9a7 7 0 0 0 14 0" />
-      </svg>
-    </button>
-  </form>
+  <%= render 'shared/search_box' %>
 <% end %>
 
 <% if @page.slug == "/" && !current_user %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,26 +1,5 @@
 <div id="search">
-<%= render 'chobble_forms/form_context',
-  model: nil,
-  scope: :search,
-  i18n_base: 'forms.search',
-  url: '#',
-  local: true do |form| %>
-
-  <%= render 'chobble_forms/fieldset', legend_key: 'search_details' do %>
-    <%= render 'chobble_forms/select',
-      field: :type,
-      options: options_for_select([
-        [t('forms.search.options.inspection'), 'inspection'],
-        [t('forms.search.options.unit'), 'unit']
-      ], 'unit') %>
-
-    <% setup = form_field_setup(:id, {field: :id}) %>
-    <%= form.label :id, setup[:field_label] %>
-    <%= form.text_field :id,
-      pattern: '[A-Za-z0-9]{8}',
-      placeholder: t('forms.search.placeholders.id', default: nil) %>
-  <% end %>
-<% end %>
+  <%= render 'shared/search_box' %>
 </div>
 
 <article id="search-results" style="display: none;">
@@ -29,25 +8,29 @@
     <thead>
       <tr>
         <th><%= t("search.results.site") %></th>
+        <th><%= t("search.results.type") %></th>
         <th><%= t("search.results.status") %></th>
         <th><%= t("search.results.action") %></th>
       </tr>
     </thead>
     <tbody id="results-body">
       <% @federated_sites.each do |site| %>
-        <tr data-site-name="<%= site[:name] %>" data-site-url="<%= site[:host].present? ? "https://#{site[:host]}" : "" %>">
-          <td>
-            <% if site[:host].present? %>
-              <a href="https://<%= site[:host] %>" target="_blank" rel="noopener">
+        <% ['unit', 'inspection'].each do |type| %>
+          <tr data-site-name="<%= site[:name] %>" data-site-url="<%= site[:host].present? ? "https://#{site[:host]}" : "" %>" data-type="<%= type %>">
+            <td>
+              <% if site[:host].present? %>
+                <a href="https://<%= site[:host] %>" target="_blank" rel="noopener">
+                  <%= t("search.sites.#{site[:name]}") %>
+                </a>
+              <% else %>
                 <%= t("search.sites.#{site[:name]}") %>
-              </a>
-            <% else %>
-              <%= t("search.sites.#{site[:name]}") %>
-            <% end %>
-          </td>
-          <td class="status"><%= t("search.status.waiting") %></td>
-          <td class="action">-</td>
-        </tr>
+              <% end %>
+            </td>
+            <td><%= t("search.types.#{type}") %></td>
+            <td class="status"><%= t("search.status.waiting") %></td>
+            <td class="action">-</td>
+          </tr>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/shared/_search_box.html.erb
+++ b/app/views/shared/_search_box.html.erb
@@ -1,0 +1,24 @@
+<form action="/search" method="get" id="homepage-search">
+  <input
+    type="text"
+    name="id"
+    placeholder="<%= t('search.homepage.placeholder') %>"
+    pattern="[A-Za-z0-9]{8}"
+    maxlength="8"
+    required>
+  <button type="submit">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24">
+      <path
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+        d="m14 14l2.5 2.5m-.067 2.025a1.48 1.48 0 1 1 2.092-2.092l3.042 3.042a1.48 1.48 0 1 1-2.092 2.092zM16 9A7 7 0 1 0 2 9a7 7 0 0 0 14 0" />
+    </svg>
+  </button>
+</form>

--- a/config/locales/search.en.yml
+++ b/config/locales/search.en.yml
@@ -11,6 +11,7 @@ en:
     results:
       heading: "Search Results"
       site: "Site"
+      type: "Type"
       status: "Status"
       action: "Action"
     status:
@@ -19,6 +20,9 @@ en:
       found: "Found"
       not_found: "Not found"
       error: "Error"
+    types:
+      unit: "Unit"
+      inspection: "Inspection"
   
   # Form translations for search
   forms:

--- a/spec/features/search_page_spec.rb
+++ b/spec/features/search_page_spec.rb
@@ -1,26 +1,16 @@
+# typed: false
+
 require "rails_helper"
 
 RSpec.feature "Search page", type: :feature do
-  scenario "displays search form with required fields" do
+  scenario "displays search form with search box matching homepage style" do
     visit search_path
 
-    # Check page title
-    expect(page).to have_content(I18n.t("forms.search.header"))
-
-    # Check form fields are present
-    within "form" do
-      # Check type select field
-      expect(page).to have_select(I18n.t("forms.search.fields.type"),
-        with_options: [
-          I18n.t("forms.search.options.inspection"),
-          I18n.t("forms.search.options.unit")
-        ])
-
-      # Check ID field
-      expect(page).to have_field(I18n.t("forms.search.fields.id"))
-
-      # Check submit button
-      expect(page).to have_button(I18n.t("forms.search.submit"))
+    # Check that the search box is present with correct attributes
+    within "#search" do
+      expect(page).to have_selector("form#homepage-search")
+      expect(page).to have_field(type: "text", name: "id")
+      expect(page).to have_button(type: "submit")
     end
 
     # Check results table is hidden initially
@@ -30,25 +20,46 @@ RSpec.feature "Search page", type: :feature do
   scenario "can submit search form" do
     visit search_path
 
-    within "form" do
-      select I18n.t("forms.search.options.inspection"),
-        from: I18n.t("forms.search.fields.type")
-      fill_in I18n.t("forms.search.fields.id"), with: "ABC12345"
-      click_button I18n.t("forms.search.submit")
+    within "#homepage-search" do
+      fill_in "id", with: "ABC12345"
+      click_button
     end
 
-    # With js: false, the form will submit but nothing will happen
-    # Just verify the form can be submitted without errors
-    expect(page).to have_current_path(search_path)
+    # Form submission includes the ID parameter
+    expect(page).to have_current_path(search_path(id: "ABC12345"))
   end
 
-  scenario "displays all federated sites in results table" do
+  scenario "displays all federated sites with both unit and inspection rows" do
     visit search_path
 
     # Check that federated sites are in the DOM (even if hidden)
     Federation.sites.each do |site|
       site_name = I18n.t("search.sites.#{site[:name]}")
-      expect(page.html).to include(site_name)
+      # Should have two entries per site (one for unit, one for inspection)
+      expect(page.html.scan(site_name).count).to eq(2)
     end
+
+    # Check that both types are shown for each site
+    expect(page.html).to include(I18n.t("search.types.unit"))
+    expect(page.html).to include(I18n.t("search.types.inspection"))
+  end
+
+  scenario "results table has correct columns" do
+    visit search_path
+
+    # Check table headers (table is hidden but present in DOM)
+    site_text = I18n.t("search.results.site")
+    type_text = I18n.t("search.results.type")
+    status_text = I18n.t("search.results.status")
+    action_text = I18n.t("search.results.action")
+
+    expect(page).to have_selector("#search-results th",
+      text: site_text, visible: false)
+    expect(page).to have_selector("#search-results th",
+      text: type_text, visible: false)
+    expect(page).to have_selector("#search-results th",
+      text: status_text, visible: false)
+    expect(page).to have_selector("#search-results th",
+      text: action_text, visible: false)
   end
 end


### PR DESCRIPTION
## Summary
- Refactors the search page to unify the search box UI across homepage and search page
- Adds support for searching both "unit" and "inspection" types simultaneously
- Updates search results table to display separate rows for each federated site and type
- Simplifies JavaScript search logic to handle new data attributes and form structure
- Improves localization with added translations for search types
- Updates feature specs to reflect UI and behavior changes

## Changes

### UI Components
- Replaced separate search form on homepage and search page with a shared partial `_search_box.html.erb`
- Search results table now includes a "Type" column and shows two rows per federated site (one for unit, one for inspection)
- Updated locale file to add translations for "unit" and "inspection" types

### JavaScript
- Modified `FederationSearch` class to:
  - Use the unified search form from homepage or search page
  - Extract `id` parameter directly from form without nested `search` namespace
  - Iterate over each federated site row for both unit and inspection types

### Tests
- Updated feature specs to:
  - Verify presence of unified search box with correct attributes
  - Confirm form submission works with new form structure
  - Check that results table includes both unit and inspection rows per site
  - Validate presence of new table headers including "Type"

## Test plan
- [x] Visit search page and homepage to confirm search box presence and functionality
- [x] Submit search form and verify correct navigation with ID parameter
- [x] Confirm results table displays two rows per federated site with correct type labels
- [x] Run feature specs to ensure all new behaviors are covered and passing

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/71d90440-8b41-432e-aad0-cd5aaa219819