### PR TITLE
Fix UK mobile phone number generation to correct digit grouping in test data helper

### DIFF
--- a/lib/test_data_helpers.rb
+++ b/lib/test_data_helpers.rb
@@ -1,9 +1,11 @@
+# typed: false
+
 # Shared test data helpers for generating realistic British data
 # Used by both factories and seeds for non-critical test data generation
 module TestDataHelpers
   # Generate realistic UK mobile numbers (07xxx format)
   def self.british_phone_number
-    "07#{rand(100..999)} #{rand(100..999)} #{SecureRandom.hex(2).to_i(16) % 10000}"
+    "07#{rand(100..999)} #{rand(100..999)} #{rand(1000..9999)}"
   end
 
   # Generate realistic UK postcodes

--- a/lib/test_data_helpers.rb
+++ b/lib/test_data_helpers.rb
@@ -3,9 +3,9 @@
 # Shared test data helpers for generating realistic British data
 # Used by both factories and seeds for non-critical test data generation
 module TestDataHelpers
-  # Generate realistic UK mobile numbers (07xxx format)
+  # Generate realistic UK mobile numbers (07xxx xxx xxx - 11 digits)
   def self.british_phone_number
-    "07#{rand(100..999)} #{rand(100..999)} #{rand(1000..9999)}"
+    "07#{rand(100..999)} #{rand(100..999)} #{rand(100..999)}"
   end
 
   # Generate realistic UK postcodes

--- a/spec/lib/test_data_helpers_spec.rb
+++ b/spec/lib/test_data_helpers_spec.rb
@@ -1,3 +1,5 @@
+# typed: false
+
 require "rails_helper"
 
 RSpec.describe TestDataHelpers do
@@ -5,8 +7,8 @@ RSpec.describe TestDataHelpers do
     it "generates valid UK mobile number format" do
       phone = described_class.british_phone_number
 
-      expect(phone).to match(/\A07\d{3} \d{3} \d{4}\z/)
-      expect(phone.length).to eq(14) # "07xxx xxx xxxx"
+      expect(phone).to match(/\A07\d{3} \d{3} \d{3}\z/)
+      expect(phone.length).to eq(13) # "07xxx xxx xxx"
     end
 
     it "always starts with 07" do


### PR DESCRIPTION
## Summary
- Corrects the UK mobile phone number format generation in the test data helper
- Changes the last group of digits from 4 digits to 3 digits to match the 11-digit UK mobile number format
- Replaces insecure and inconsistent hex-based number generation with a proper numeric range

## Changes

### Test Data Helpers
- Updated `british_phone_number` method to generate the last three digits using `rand(100..999)` instead of converting a hex string to integer
- Adjusted the phone number format to "07xxx xxx xxx" (13 characters including spaces) to reflect the correct UK mobile number format
- Added `# typed: false` to the file for Sorbet type checking compatibility

## Test plan
- [x] Verify generated UK mobile numbers follow the correct 07xxx xxx xxx format
- [x] Confirm numbers are numeric and realistic for UK mobile phone standards
- [x] Run existing tests that utilize this helper to ensure no breakage

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/53e6d67c-eef2-4162-af12-0e1cd19780d5