### PR TITLE
Add basic PWA support with manifest and meta tags

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
     <%= javascript_importmap_tags %>
 
     <%= favicon_link_tag asset_path("favicon.svg") %>
+    <link rel="manifest" href="/manifest.json">
+    <meta name="theme-color" content="#000000">
+    <link rel="apple-touch-icon" href="/icon.png">
     <% unless Rails.env.test? %>
       <script>
         window.goatcounter = {no_onload: true}

--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -1,5 +1,6 @@
 {
-  "name": "PlayTest",
+  "name": "Play-Test",
+  "short_name": "Play-Test",
   "icons": [
     {
       "src": "/icon.png",
@@ -16,7 +17,7 @@
   "start_url": "/",
   "display": "standalone",
   "scope": "/",
-  "description": "PlayTest.",
-  "theme_color": "red",
-  "background_color": "red"
+  "description": "BS EN 14960 Inspection Logger & Database",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
 }


### PR DESCRIPTION
## Summary
- Adds basic Progressive Web App (PWA) support to the Play-Test application
- Includes manifest file updates and necessary meta tags in the application layout

## Changes

### Manifest Updates
- Renamed app name and short name to "Play-Test" for consistency
- Updated description to "BS EN 14960 Inspection Logger & Database"
- Changed theme color to black (#000000) and background color to white (#ffffff)

### Layout Updates
- Added `<link rel="manifest" href="/manifest.json">` to include the manifest
- Added `<meta name="theme-color" content="#000000">` for theme color on supported browsers
- Added `<link rel="apple-touch-icon" href="/icon.png">` for iOS home screen icon

## Test plan
- Verify manifest.json is served correctly with updated fields
- Confirm meta tags and manifest link are present in the HTML head
- Test adding the app to home screen on supported devices
- Check theme color and icon display on supported browsers and platforms

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/73bcf14e-fce0-4050-b4be-811e7ad7b04b