### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,5 +1,8 @@
 name: "Security: Vulnerability Scanning"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/chobbledotcom/play-test/security/code-scanning/2](https://github.com/chobbledotcom/play-test/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/security-scan.yml`. Since none of the jobs require write access to repository contents or other resources, the minimal required permission is `contents: read`. This block can be added at the root level of the workflow (above `jobs:`), which will apply to all jobs unless overridden. No changes to the steps or job definitions are needed. The fix is to insert the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

This ensures that the GITHUB_TOKEN used by the workflow only has read access to repository contents, following best security practices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
