### PR TITLE
Enhance terragon-setup.sh with nix shell bundle install and usage instructions

### DIFF
--- a/terragon-setup.sh
+++ b/terragon-setup.sh
@@ -2,3 +2,25 @@
 set -euo pipefail
 
 curl -fsSL https://install.determinate.systems/nix | sh -s -- install --determinate --no-confirm
+
+# Add nix to PATH
+export PATH="$HOME/.nix-profile/bin:$PATH"
+
+# Run bundle install inside nix develop shell
+echo "Running bundle install in nix develop shell..."
+nix develop --command bundle install
+
+# Print instructions for Terry
+echo ""
+echo "================== TERRY INSTRUCTIONS =================="
+echo "To run rspec tests with the nix shell, use:"
+echo ""
+echo "  nix develop --command bundle exec rspec"
+echo ""
+echo "Or enter the nix shell first and run commands:"
+echo ""
+echo "  nix develop"
+echo "  bundle exec rspec"
+echo ""
+echo "The nix shell provides all required dependencies."
+echo "========================================================"


### PR DESCRIPTION
## Summary
- Adds automatic bundle install inside the nix develop shell
- Updates PATH to include nix profile binaries
- Provides clear instructions for running rspec tests using the nix shell

## Changes

### terragon-setup.sh
- Installs nix with determinate and no confirmation flags
- Exports nix profile bin directory to PATH
- Runs `bundle install` inside the nix develop shell to ensure dependencies are installed
- Prints detailed instructions for using the nix shell to run rspec tests either directly or interactively

## Test plan
- Verified that running the script installs nix and sets up the environment
- Confirmed that `bundle install` runs successfully inside the nix shell
- Checked that the printed instructions are clear and accurate for developers to run tests with nix shell

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/16c0b5d8-a187-40f5-97a8-dbd7f10366b8