### PR TITLE
Add cmake installation to Dockerfile build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libssl-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential cmake git libssl-dev pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
## Summary
- Adds installation of `cmake` package in the Dockerfile build stage
- Ensures `cmake` is available alongside other build dependencies

## Changes

### Dockerfile
- Modified the `apt-get install` command to include `cmake` in the list of packages installed during the build stage

## Test plan
- [ ] Build the Docker image to verify that `cmake` is installed correctly
- [ ] Confirm that the build process completes without errors related to missing `cmake`

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/26058ad0-4a1d-4493-90ca-dd90623c714c