### PR TITLE
Replace nil specs with Sorbet type checks in TestDataHelpers

### DIFF
--- a/lib/test_data_helpers.rb
+++ b/lib/test_data_helpers.rb
@@ -1,14 +1,17 @@
-# typed: false
+# typed: strict
 
 # Shared test data helpers for generating realistic British data
 # Used by both factories and seeds for non-critical test data generation
 module TestDataHelpers
+  extend T::Sig
   # Generate realistic UK mobile numbers (07xxx xxx xxx - 11 digits)
+  sig { returns(String) }
   def self.british_phone_number
     "07#{rand(100..999)} #{rand(100..999)} #{rand(100..999)}"
   end
 
   # Generate realistic UK postcodes
+  sig { returns(String) }
   def self.british_postcode
     prefixes = %w[SW SE NW N E W EC WC B M L G EH CF BS OX CB]
     prefix = prefixes.sample
@@ -17,6 +20,7 @@ module TestDataHelpers
   end
 
   # Generate realistic UK street addresses
+  sig { returns(String) }
   def self.british_address
     streets = %w[
       High\ Street
@@ -56,11 +60,13 @@ module TestDataHelpers
     Belfast
   ].freeze
 
+  sig { returns(String) }
   def self.british_city
     BRITISH_CITIES.sample
   end
 
   # Generate a British company name variation
+  sig { params(base_name: String).returns(String) }
   def self.british_company_name(base_name)
     suffixes = ["Ltd", "UK", "Services", "Solutions", "Group", "& Co"]
     "#{base_name} #{suffixes.sample}"

--- a/spec/lib/test_data_helpers_spec.rb
+++ b/spec/lib/test_data_helpers_spec.rb
@@ -142,12 +142,6 @@ RSpec.describe TestDataHelpers do
       end
     end
 
-    context "with nil base name" do
-      it "handles nil gracefully" do
-        expect { described_class.british_company_name(nil) }.not_to raise_error
-      end
-    end
-
     it "generates different company names for same base" do
       base_name = "TestCorp"
       names = 10.times.map { described_class.british_company_name(base_name) }


### PR DESCRIPTION
## Summary
- Converted `TestDataHelpers` module to use Sorbet strict typing
- Added Sorbet signatures to all helper methods for better type safety
- Removed redundant RSpec tests that checked for nil handling, relying on Sorbet instead

## Changes

### Type System
- Changed `# typed: false` to `# typed: strict` in `lib/test_data_helpers.rb`
- Added `extend T::Sig` to enable Sorbet signatures
- Added `sig` annotations for all public methods in `TestDataHelpers`:
  - `british_phone_number` returns `String`
  - `british_postcode` returns `String`
  - `british_address` returns `String`
  - `british_city` returns `String`
  - `british_company_name` takes a `String` and returns a `String`

### Tests
- Removed the spec context that tested `british_company_name` with a nil base name, as Sorbet typing enforces non-nil `String` input

## Test plan
- Existing tests for `TestDataHelpers` pass without errors
- Confirmed no regressions by running full test suite

This change improves code robustness by leveraging Sorbet's static type checking and removes unnecessary runtime nil checks in tests.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f979d69b-f156-4b6f-a0e4-671badd73cc4