### PR TITLE
Refactor form YAMLs to use symbol keys directly and simplify form config loading

### DIFF
--- a/app/models/concerns/form_configurable.rb
+++ b/app/models/concerns/form_configurable.rb
@@ -19,7 +19,7 @@ module FormConfigurable
       file_name = name.demodulize.underscore
       config_path = Rails.root.join("config/forms/#{file_name}.yml")
       yaml_content = YAML.load_file(config_path)
-      yaml_content.deep_symbolize_keys
+      yaml_content.deep_symbolize_keys!
       yaml_content[:form_fields]
     end
   end

--- a/app/models/concerns/form_configurable.rb
+++ b/app/models/concerns/form_configurable.rb
@@ -19,11 +19,8 @@ module FormConfigurable
       file_name = name.demodulize.underscore
       config_path = Rails.root.join("config/forms/#{file_name}.yml")
       yaml_content = YAML.load_file(config_path)
-      yaml_content["form_fields"].map do |fieldset|
-        fieldset = fieldset.deep_symbolize_keys
-        # Fields now have symbols directly in YAML, no conversion needed
-        fieldset
-      end
+      yaml_content.deep_symbolize_keys
+      yaml_content[:form_fields]
     end
   end
 end

--- a/app/models/concerns/form_configurable.rb
+++ b/app/models/concerns/form_configurable.rb
@@ -21,14 +21,7 @@ module FormConfigurable
       yaml_content = YAML.load_file(config_path)
       yaml_content["form_fields"].map do |fieldset|
         fieldset = fieldset.deep_symbolize_keys
-        # Also symbolize the field and partial values
-        if fieldset[:fields]
-          fieldset[:fields] = fieldset[:fields].map do |field_config|
-            field_config[:field] = field_config[:field].to_sym
-            field_config[:partial] = field_config[:partial].to_sym
-            field_config
-          end
-        end
+        # Fields now have symbols directly in YAML, no conversion needed
         fieldset
       end
     end

--- a/app/models/concerns/form_configurable.rb
+++ b/app/models/concerns/form_configurable.rb
@@ -15,15 +15,10 @@ module FormConfigurable
 
     sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
     def load_form_config_from_yaml
-      # Remove namespace and use just the class name
       file_name = name.demodulize.underscore
       config_path = Rails.root.join("config/forms/#{file_name}.yml")
       yaml_content = YAML.load_file(config_path)
-      yaml_content["form_fields"].map do |fieldset|
-        fieldset = fieldset.deep_symbolize_keys
-        # Fields now have symbols directly in YAML, no conversion needed
-        fieldset
-      end
+      yaml_content.deep_symbolize_keys!
     end
   end
 end

--- a/app/models/concerns/form_configurable.rb
+++ b/app/models/concerns/form_configurable.rb
@@ -15,10 +15,15 @@ module FormConfigurable
 
     sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
     def load_form_config_from_yaml
+      # Remove namespace and use just the class name
       file_name = name.demodulize.underscore
       config_path = Rails.root.join("config/forms/#{file_name}.yml")
       yaml_content = YAML.load_file(config_path)
-      yaml_content.deep_symbolize_keys!
+      yaml_content["form_fields"].map do |fieldset|
+        fieldset = fieldset.deep_symbolize_keys
+        # Fields now have symbols directly in YAML, no conversion needed
+        fieldset
+      end
     end
   end
 end

--- a/config/forms/anchorage_assessment.yml
+++ b/config/forms/anchorage_assessment.yml
@@ -3,22 +3,22 @@ form_fields:
   - legend_i18n_key: anchor_counts
     fields:
       - partial: number_pass_fail_comment
-        field: num_low_anchors
+        field: :num_low_anchors
         attributes:
           step: 1
           min: 0
       - partial: number_pass_fail_comment
-        field: num_high_anchors
+        field: :num_high_anchors
         attributes:
           step: 1
           min: 0
   - legend_i18n_key: anchor_quality
     fields:
       - partial: pass_fail_comment
-        field: anchor_accessories
+        field: :anchor_accessories
       - partial: pass_fail_comment
-        field: anchor_degree
+        field: :anchor_degree
       - partial: pass_fail_comment
-        field: anchor_type
+        field: :anchor_type
       - partial: pass_fail_comment
-        field: pull_strength
+        field: :pull_strength

--- a/config/forms/anchorage_assessment.yml
+++ b/config/forms/anchorage_assessment.yml
@@ -2,23 +2,23 @@
 form_fields:
   - legend_i18n_key: anchor_counts
     fields:
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :num_low_anchors
         attributes:
           step: 1
           min: 0
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :num_high_anchors
         attributes:
           step: 1
           min: 0
   - legend_i18n_key: anchor_quality
     fields:
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :anchor_accessories
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :anchor_degree
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :anchor_type
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :pull_strength

--- a/config/forms/enclosed_assessment.yml
+++ b/config/forms/enclosed_assessment.yml
@@ -2,9 +2,9 @@
 form_fields:
   - legend_i18n_key: exit_requirements
     fields:
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :exit_number
         attributes:
           min: 1
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :exit_sign_always_visible

--- a/config/forms/enclosed_assessment.yml
+++ b/config/forms/enclosed_assessment.yml
@@ -3,8 +3,8 @@ form_fields:
   - legend_i18n_key: exit_requirements
     fields:
       - partial: number_pass_fail_comment
-        field: exit_number
+        field: :exit_number
         attributes:
           min: 1
       - partial: pass_fail_comment
-        field: exit_sign_always_visible
+        field: :exit_sign_always_visible

--- a/config/forms/fan_assessment.yml
+++ b/config/forms/fan_assessment.yml
@@ -2,24 +2,24 @@
 form_fields:
   - legend_i18n_key: fan_assessment
     fields:
-      - partial: text_field
+      - partial: :text_field
         field: :fan_size_type
-      - partial: number
+      - partial: :number
         field: :number_of_blowers
         attributes:
           step: 1
-      - partial: text_field
+      - partial: :text_field
         field: :blower_serial
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :blower_tube_length
         attributes:
           step: 0.1
           max: 10
-      - partial: pass_fail_na_comment
+      - partial: :pass_fail_na_comment
         field: :blower_flap
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :blower_finger
-      - partial: pass_fail_na_comment
+      - partial: :pass_fail_na_comment
         field: :pat
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :blower_visual

--- a/config/forms/fan_assessment.yml
+++ b/config/forms/fan_assessment.yml
@@ -3,23 +3,23 @@ form_fields:
   - legend_i18n_key: fan_assessment
     fields:
       - partial: text_field
-        field: fan_size_type
+        field: :fan_size_type
       - partial: number
-        field: number_of_blowers
+        field: :number_of_blowers
         attributes:
           step: 1
       - partial: text_field
-        field: blower_serial
+        field: :blower_serial
       - partial: number_pass_fail_comment
-        field: blower_tube_length
+        field: :blower_tube_length
         attributes:
           step: 0.1
           max: 10
       - partial: pass_fail_na_comment
-        field: blower_flap
+        field: :blower_flap
       - partial: pass_fail_comment
-        field: blower_finger
+        field: :blower_finger
       - partial: pass_fail_na_comment
-        field: pat
+        field: :pat
       - partial: pass_fail_comment
-        field: blower_visual
+        field: :blower_visual

--- a/config/forms/inspection.yml
+++ b/config/forms/inspection.yml
@@ -3,25 +3,25 @@ form_fields:
   - legend_i18n_key: unit_dimensions
     fields:
       - partial: decimal_comment
-        field: width
+        field: :width
         attributes:
           min: 0
           max: 200
       - partial: decimal_comment
-        field: length
+        field: :length
         attributes:
           min: 0
           max: 200
       - partial: decimal_comment
-        field: height
+        field: :height
         attributes:
           min: 0
           max: 50
   - legend_i18n_key: unit_configuration
     fields:
       - partial: yes_no_radio
-        field: has_slide
+        field: :has_slide
       - partial: yes_no_radio
-        field: is_totally_enclosed
+        field: :is_totally_enclosed
       - partial: yes_no_radio
-        field: indoor_only
+        field: :indoor_only

--- a/config/forms/inspection.yml
+++ b/config/forms/inspection.yml
@@ -2,26 +2,26 @@
 form_fields:
   - legend_i18n_key: unit_dimensions
     fields:
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :width
         attributes:
           min: 0
           max: 200
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :length
         attributes:
           min: 0
           max: 200
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :height
         attributes:
           min: 0
           max: 50
   - legend_i18n_key: unit_configuration
     fields:
-      - partial: yes_no_radio
+      - partial: :yes_no_radio
         field: :has_slide
-      - partial: yes_no_radio
+      - partial: :yes_no_radio
         field: :is_totally_enclosed
-      - partial: yes_no_radio
+      - partial: :yes_no_radio
         field: :indoor_only

--- a/config/forms/inspector_company.yml
+++ b/config/forms/inspector_company.yml
@@ -3,38 +3,38 @@ form_fields:
   - legend_i18n_key: company_details
     fields:
       - partial: text_field
-        field: name
+        field: :name
         attributes:
           required: true
       - partial: text_field
-        field: email
+        field: :email
         attributes:
           type: email_field
       - partial: text_field
-        field: phone
+        field: :phone
         attributes:
           type: telephone_field
           required: true
   - legend_i18n_key: contact_information
     fields:
       - partial: text_area
-        field: address
+        field: :address
         attributes:
           rows: 3
           required: true
       - partial: text_field
-        field: city
+        field: :city
       - partial: text_field
-        field: postal_code
+        field: :postal_code
       - partial: text_field
-        field: country
+        field: :country
   - legend_i18n_key: company_status
     fields:
       - partial: checkbox
-        field: active
+        field: :active
       - partial: text_area
-        field: notes
+        field: :notes
         attributes:
           rows: 4
       - partial: file_field
-        field: logo
+        field: :logo

--- a/config/forms/inspector_company.yml
+++ b/config/forms/inspector_company.yml
@@ -2,39 +2,39 @@
 form_fields:
   - legend_i18n_key: company_details
     fields:
-      - partial: text_field
+      - partial: :text_field
         field: :name
         attributes:
           required: true
-      - partial: text_field
+      - partial: :text_field
         field: :email
         attributes:
           type: email_field
-      - partial: text_field
+      - partial: :text_field
         field: :phone
         attributes:
           type: telephone_field
           required: true
   - legend_i18n_key: contact_information
     fields:
-      - partial: text_area
+      - partial: :text_area
         field: :address
         attributes:
           rows: 3
           required: true
-      - partial: text_field
+      - partial: :text_field
         field: :city
-      - partial: text_field
+      - partial: :text_field
         field: :postal_code
-      - partial: text_field
+      - partial: :text_field
         field: :country
   - legend_i18n_key: company_status
     fields:
-      - partial: checkbox
+      - partial: :checkbox
         field: :active
-      - partial: text_area
+      - partial: :text_area
         field: :notes
         attributes:
           rows: 4
-      - partial: file_field
+      - partial: :file_field
         field: :logo

--- a/config/forms/materials_assessment.yml
+++ b/config/forms/materials_assessment.yml
@@ -2,21 +2,21 @@
 form_fields:
   - legend_i18n_key: materials_assessment
     fields:
-      - partial: number_pass_fail_na_comment
-        field: ropes
+      - partial: :number_pass_fail_na_comment
+        field: :ropes
         attributes:
           min: 0
-      - partial: pass_fail_na_comment
-        field: retention_netting
-      - partial: pass_fail_na_comment
-        field: zips
-      - partial: pass_fail_na_comment
-        field: windows
-      - partial: pass_fail_na_comment
-        field: artwork
-      - partial: pass_fail_comment
-        field: thread
-      - partial: pass_fail_comment
-        field: fabric_strength
-      - partial: pass_fail_comment
-        field: fire_retardant
+      - partial: :pass_fail_na_comment
+        field: :retention_netting
+      - partial: :pass_fail_na_comment
+        field: :zips
+      - partial: :pass_fail_na_comment
+        field: :windows
+      - partial: :pass_fail_na_comment
+        field: :artwork
+      - partial: :pass_fail_comment
+        field: :thread
+      - partial: :pass_fail_comment
+        field: :fabric_strength
+      - partial: :pass_fail_comment
+        field: :fire_retardant

--- a/config/forms/page.yml
+++ b/config/forms/page.yml
@@ -2,27 +2,27 @@
 form_fields:
   - legend_i18n_key: page_details
     fields:
-      - partial: text_field
+      - partial: :text_field
         field: :slug
         attributes:
           required: true
-      - partial: text_field
+      - partial: :text_field
         field: :link_title
         attributes:
           required: true
-      - partial: checkbox
+      - partial: :checkbox
         field: :is_snippet
   - legend_i18n_key: seo_metadata
     fields:
-      - partial: text_field
+      - partial: :text_field
         field: :meta_title
-      - partial: text_area
+      - partial: :text_area
         field: :meta_description
         attributes:
           rows: 3
   - legend_i18n_key: content
     fields:
-      - partial: text_area
+      - partial: :text_area
         field: :content
         attributes:
           rows: 20

--- a/config/forms/page.yml
+++ b/config/forms/page.yml
@@ -3,27 +3,27 @@ form_fields:
   - legend_i18n_key: page_details
     fields:
       - partial: text_field
-        field: slug
+        field: :slug
         attributes:
           required: true
       - partial: text_field
-        field: link_title
+        field: :link_title
         attributes:
           required: true
       - partial: checkbox
-        field: is_snippet
+        field: :is_snippet
   - legend_i18n_key: seo_metadata
     fields:
       - partial: text_field
-        field: meta_title
+        field: :meta_title
       - partial: text_area
-        field: meta_description
+        field: :meta_description
         attributes:
           rows: 3
   - legend_i18n_key: content
     fields:
       - partial: text_area
-        field: content
+        field: :content
         attributes:
           rows: 20
           required: true

--- a/config/forms/session.yml
+++ b/config/forms/session.yml
@@ -3,14 +3,14 @@ form_fields:
   - legend_i18n_key: credentials
     fields:
       - partial: text_field
-        field: email
+        field: :email
         attributes:
           type: email_field
           required: true
       - partial: text_field
-        field: password
+        field: :password
         attributes:
           type: password_field
           required: true
       - partial: checkbox
-        field: remember_me
+        field: :remember_me

--- a/config/forms/session.yml
+++ b/config/forms/session.yml
@@ -2,15 +2,15 @@
 form_fields:
   - legend_i18n_key: credentials
     fields:
-      - partial: text_field
+      - partial: :text_field
         field: :email
         attributes:
           type: email_field
           required: true
-      - partial: text_field
+      - partial: :text_field
         field: :password
         attributes:
           type: password_field
           required: true
-      - partial: checkbox
+      - partial: :checkbox
         field: :remember_me

--- a/config/forms/slide_assessment.yml
+++ b/config/forms/slide_assessment.yml
@@ -2,34 +2,34 @@
 form_fields:
   - legend_i18n_key: slide_dimensions
     fields:
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :slide_platform_height
         attributes:
           min: 0
           max: 50
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :slide_wall_height
         attributes:
           min: 0
           max: 50
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :slide_first_metre_height
         attributes:
           min: 0
           max: 50
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :slide_beyond_first_metre_height
         attributes:
           min: 0
           max: 50
-      - partial: yes_no_radio_comment
+      - partial: :yes_no_radio_comment
         field: :slide_permanent_roof
-      - partial: pass_fail_na_comment
+      - partial: :pass_fail_na_comment
         field: :clamber_netting
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :runout
         attributes:
           min: 0
           max: 50
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :slip_sheet

--- a/config/forms/slide_assessment.yml
+++ b/config/forms/slide_assessment.yml
@@ -3,33 +3,33 @@ form_fields:
   - legend_i18n_key: slide_dimensions
     fields:
       - partial: decimal_comment
-        field: slide_platform_height
+        field: :slide_platform_height
         attributes:
           min: 0
           max: 50
       - partial: decimal_comment
-        field: slide_wall_height
+        field: :slide_wall_height
         attributes:
           min: 0
           max: 50
       - partial: decimal_comment
-        field: slide_first_metre_height
+        field: :slide_first_metre_height
         attributes:
           min: 0
           max: 50
       - partial: decimal_comment
-        field: slide_beyond_first_metre_height
+        field: :slide_beyond_first_metre_height
         attributes:
           min: 0
           max: 50
       - partial: yes_no_radio_comment
-        field: slide_permanent_roof
+        field: :slide_permanent_roof
       - partial: pass_fail_na_comment
-        field: clamber_netting
+        field: :clamber_netting
       - partial: number_pass_fail_comment
-        field: runout
+        field: :runout
         attributes:
           min: 0
           max: 50
       - partial: pass_fail_comment
-        field: slip_sheet
+        field: :slip_sheet

--- a/config/forms/structure_assessment.yml
+++ b/config/forms/structure_assessment.yml
@@ -3,59 +3,59 @@ form_fields:
   - legend_i18n_key: fabric_construction
     fields:
       - partial: pass_fail_comment
-        field: seam_integrity
+        field: :seam_integrity
       - partial: pass_fail_comment
-        field: stitch_length
+        field: :stitch_length
       - partial: pass_fail_comment
-        field: air_loss
+        field: :air_loss
       - partial: pass_fail_comment
-        field: straight_walls
+        field: :straight_walls
       - partial: pass_fail_comment
-        field: sharp_edges
+        field: :sharp_edges
   - legend_i18n_key: structural_safety
     fields:
       - partial: pass_fail_comment
-        field: unit_stable
+        field: :unit_stable
       - partial: pass_fail_comment
-        field: evacuation_time
+        field: :evacuation_time
       - partial: number_pass_fail_comment
-        field: step_ramp_size
+        field: :step_ramp_size
         attributes:
           step: 1
           min: 0
       - partial: number_pass_fail_comment
-        field: platform_height
+        field: :platform_height
         attributes:
           step: 1
           min: 10
       - partial: number_pass_fail_comment
-        field: critical_fall_off_height
+        field: :critical_fall_off_height
         attributes:
           step: 1
           min: 10
       - partial: number_pass_fail_comment
-        field: unit_pressure
+        field: :unit_pressure
         attributes:
           step: 0.01
           min: 0
   - legend_i18n_key: trough_assessment
     fields:
       - partial: integer_comment
-        field: trough_depth
+        field: :trough_depth
         attributes:
           min: 0
           add_not_applicable: true
       - partial: integer_comment
-        field: trough_adjacent_panel_width
+        field: :trough_adjacent_panel_width
         attributes:
           min: 0
       - partial: pass_fail_comment
-        field: trough
+        field: :trough
   - legend_i18n_key: safety_compliance
     fields:
       - partial: pass_fail_comment
-        field: entrapment
+        field: :entrapment
       - partial: pass_fail_comment
-        field: markings
+        field: :markings
       - partial: pass_fail_comment
-        field: grounding
+        field: :grounding

--- a/config/forms/structure_assessment.yml
+++ b/config/forms/structure_assessment.yml
@@ -2,60 +2,60 @@
 form_fields:
   - legend_i18n_key: fabric_construction
     fields:
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :seam_integrity
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :stitch_length
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :air_loss
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :straight_walls
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :sharp_edges
   - legend_i18n_key: structural_safety
     fields:
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :unit_stable
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :evacuation_time
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :step_ramp_size
         attributes:
           step: 1
           min: 0
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :platform_height
         attributes:
           step: 1
           min: 10
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :critical_fall_off_height
         attributes:
           step: 1
           min: 10
-      - partial: number_pass_fail_comment
+      - partial: :number_pass_fail_comment
         field: :unit_pressure
         attributes:
           step: 0.01
           min: 0
   - legend_i18n_key: trough_assessment
     fields:
-      - partial: integer_comment
+      - partial: :integer_comment
         field: :trough_depth
         attributes:
           min: 0
           add_not_applicable: true
-      - partial: integer_comment
+      - partial: :integer_comment
         field: :trough_adjacent_panel_width
         attributes:
           min: 0
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :trough
   - legend_i18n_key: safety_compliance
     fields:
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :entrapment
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :markings
-      - partial: pass_fail_comment
+      - partial: :pass_fail_comment
         field: :grounding

--- a/config/forms/user_height_assessment.yml
+++ b/config/forms/user_height_assessment.yml
@@ -2,51 +2,51 @@
 form_fields:
   - legend_i18n_key: height_measurements
     fields:
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :containing_wall_height
         attributes:
           min: 0
           max: 50
   - legend_i18n_key: play_area
     fields:
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :play_area_length
         attributes:
           min: 0
           max: 200
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :play_area_width
         attributes:
           min: 0
           max: 200
-      - partial: decimal_comment
+      - partial: :decimal_comment
         field: :negative_adjustment
         attributes:
           min: 0
           max: 200
   - legend_i18n_key: user_capacity
     fields:
-      - partial: number
-        field: users_at_1000mm
+      - partial: :number
+        field: :users_at_1000mm
         attributes:
           min: 0
           step: 1
-      - partial: number
-        field: users_at_1200mm
+      - partial: :number
+        field: :users_at_1200mm
         attributes:
           min: 0
           step: 1
-      - partial: number
-        field: users_at_1500mm
+      - partial: :number
+        field: :users_at_1500mm
         attributes:
           min: 0
           step: 1
-      - partial: number
-        field: users_at_1800mm
+      - partial: :number
+        field: :users_at_1800mm
         attributes:
           min: 0
           step: 1
   - legend_i18n_key: tallest_user_capacity
     fields:
-      - partial: text_area
+      - partial: :text_area
         field: :custom_user_height_comment

--- a/config/forms/user_height_assessment.yml
+++ b/config/forms/user_height_assessment.yml
@@ -3,24 +3,24 @@ form_fields:
   - legend_i18n_key: height_measurements
     fields:
       - partial: decimal_comment
-        field: containing_wall_height
+        field: :containing_wall_height
         attributes:
           min: 0
           max: 50
   - legend_i18n_key: play_area
     fields:
       - partial: decimal_comment
-        field: play_area_length
+        field: :play_area_length
         attributes:
           min: 0
           max: 200
       - partial: decimal_comment
-        field: play_area_width
+        field: :play_area_width
         attributes:
           min: 0
           max: 200
       - partial: decimal_comment
-        field: negative_adjustment
+        field: :negative_adjustment
         attributes:
           min: 0
           max: 200
@@ -49,4 +49,4 @@ form_fields:
   - legend_i18n_key: tallest_user_capacity
     fields:
       - partial: text_area
-        field: custom_user_height_comment
+        field: :custom_user_height_comment

--- a/spec/lib/form_yaml_database_schema_spec.rb
+++ b/spec/lib/form_yaml_database_schema_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Form YAML Database Schema Validation" do
 
         # Only add base field if partial doesn't start with pass_fail
         # (for pass_fail partials, only the _pass field exists in DB)
-        unless partial.start_with?("pass_fail")
+        unless partial.to_s.start_with?("pass_fail")
           fields << field
         end
 

--- a/spec/lib/form_yaml_database_schema_spec.rb
+++ b/spec/lib/form_yaml_database_schema_spec.rb
@@ -218,12 +218,12 @@ RSpec.describe "Form YAML Database Schema Validation" do
             end
 
             # If partial contains pass_fail, it needs the _pass field
-            if partial.include?("pass_fail")
+            if partial.to_s.include?("pass_fail")
               required_fields << "#{field}_pass"
             end
 
             # If partial contains comment, it needs the _comment field
-            if partial.include?("comment")
+            if partial.to_s.include?("comment")
               required_fields << "#{field}_comment"
             end
 

--- a/spec/lib/form_yaml_database_schema_spec.rb
+++ b/spec/lib/form_yaml_database_schema_spec.rb
@@ -211,20 +211,19 @@ RSpec.describe "Form YAML Database Schema Validation" do
             # Determine which database fields need to exist
             # based on partial name
             required_fields = []
-            partial_str = partial.to_s
 
             # If partial doesn't start with pass_fail, it needs the base field
-            unless partial_str.start_with?("pass_fail")
+            unless partial.start_with?("pass_fail")
               required_fields << field.to_s
             end
 
             # If partial contains pass_fail, it needs the _pass field
-            if partial_str.include?("pass_fail")
+            if partial.include?("pass_fail")
               required_fields << "#{field}_pass"
             end
 
             # If partial contains comment, it needs the _comment field
-            if partial_str.include?("comment")
+            if partial.include?("comment")
               required_fields << "#{field}_comment"
             end
 

--- a/spec/lib/form_yaml_database_schema_spec.rb
+++ b/spec/lib/form_yaml_database_schema_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Form YAML Database Schema Validation" do
 
         # Only add base field if partial doesn't start with pass_fail
         # (for pass_fail partials, only the _pass field exists in DB)
-        unless partial.to_s.start_with?("pass_fail")
+        unless partial.start_with?("pass_fail")
           fields << field
         end
 

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -5,9 +5,7 @@ module FormHelpers
   # Load form YAML configuration with fully symbolized keys
   # Returns the full YAML content with all keys symbolized
   def get_form_config(path)
-    yaml_content = YAML.load_file(path).deep_symbolize_keys!
-    # Fields now have symbols directly in YAML, no conversion needed
-    yaml_content
+    YAML.load_file(path).deep_symbolize_keys!
   end
 
   def fill_in_form(form_name, field_name, value)

--- a/spec/support/form_helpers.rb
+++ b/spec/support/form_helpers.rb
@@ -3,19 +3,10 @@
 
 module FormHelpers
   # Load form YAML configuration with fully symbolized keys
-  # Returns the full YAML content with all keys and field/partial values symbolized
+  # Returns the full YAML content with all keys symbolized
   def get_form_config(path)
     yaml_content = YAML.load_file(path).deep_symbolize_keys!
-
-    # Also symbolize field and partial values if form_fields exist
-    yaml_content[:form_fields]&.each do |fieldset|
-      fieldset[:fields].map! do |field_config|
-        field_config[:field] = field_config[:field].to_sym
-        field_config[:partial] = field_config[:partial].to_sym
-        field_config
-      end
-    end
-
+    # Fields now have symbols directly in YAML, no conversion needed
     yaml_content
   end
 


### PR DESCRIPTION
## Summary
- Refactored form YAML configuration files to use symbols directly for `field` and `partial` keys
- Simplified `FormConfigurable` concern by removing redundant symbolization logic
- Updated test helper to load YAML with fully symbolized keys without extra conversion

## Changes

### Form Configuration
- Updated multiple form YAML files (`anchorage_assessment.yml`, `enclosed_assessment.yml`, `fan_assessment.yml`, etc.) to prefix `field` and `partial` values with `:` to denote symbols
- Removed code in `FormConfigurable` concern that converted string keys to symbols since YAML now contains symbols directly

### Test Support
- Modified `get_form_config` helper in `spec/support/form_helpers.rb` to load YAML with deep symbolization only, removing manual symbol conversion of fields and partials

## Benefits
- Cleaner and more consistent form configuration files
- Reduced runtime processing by leveraging YAML symbol keys directly
- Simplified codebase with less manual key conversion

## Test plan
- Verified existing tests pass with updated form YAMLs and refactored loading logic
- Manual inspection of form rendering to ensure fields and partials are correctly recognized as symbols

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ae0f4194-0bdd-4f7c-b105-5f490cc23fd4