### PR TITLE
Fix EN14960 wall height calculation workaround in SafetyStandardsController

### DIFF
--- a/app/controllers/safety_standards_controller.rb
+++ b/app/controllers/safety_standards_controller.rb
@@ -156,7 +156,7 @@ class SafetyStandardsController < ApplicationController
   sig { void }
   def calculate_safety_standard
     type = params[:calculation][:type]
-    
+
     case type
     when "anchors"
       calculate_anchors
@@ -250,24 +250,7 @@ class SafetyStandardsController < ApplicationController
 
   sig { params(platform_height: Float, user_height: Float).returns(T.untyped) }
   def build_wall_height_result(platform_height, user_height)
-    # Workaround for EN14960 v0.4.0 bug where it returns Integer 0 instead of Float 0.0
-    # when platform_height < 0.6
-    begin
-      EN14960.calculate_wall_height(
-        platform_height, user_height
-      )
-    rescue TypeError => e
-      if e.message.include?("got type Integer with value 0")
-        # Return the expected response for no walls required
-        EN14960::CalculatorResponse.new(
-          value: 0.0,
-          value_suffix: "m",
-          breakdown: [["No walls required", "Platform height < 0.6m"]]
-        )
-      else
-        raise e
-      end
-    end
+    EN14960.calculate_wall_height(platform_height, user_height)
   end
 
   sig { returns(T::Hash[Symbol, T.untyped]) }


### PR DESCRIPTION
## Summary
- Removes workaround for EN14960 v0.4.0 bug in `build_wall_height_result` method
- Simplifies wall height calculation by directly calling `EN14960.calculate_wall_height`

## Changes

### SafetyStandardsController
- Deleted error handling for `TypeError` caused by EN14960 returning Integer 0 instead of Float 0.0
- Cleaned up `build_wall_height_result` method to directly return the result of `EN14960.calculate_wall_height`

## Test plan
- Verify that wall height calculations behave correctly without the previous workaround
- Ensure no regressions occur in safety standard calculations related to wall height
- Run existing automated tests for safety standards to confirm stability

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5aad34d6-9e74-4436-9cd6-2f05ca0f59e0