### PR TITLE
Add comprehensive tests for PdfGeneratorService::HeaderGenerator#prepare_logo

### DIFF
--- a/spec/services/pdf_generator_service/header_generator_spec.rb
+++ b/spec/services/pdf_generator_service/header_generator_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+RSpec.describe PdfGeneratorService::HeaderGenerator do
+  let(:user) { create(:user) }
+  let(:pdf) { Prawn::Document.new }
+  let(:logo_height) { PdfGeneratorService::Configuration::LOGO_HEIGHT }
+  let(:expected_logo_width) { logo_height * 2 + 10 }
+
+  describe ".prepare_logo" do
+    context "when PDF_LOGO environment variable is set" do
+      let(:logo_filename) { "test_logo.png" }
+      let(:logo_path) { Rails.root.join("app", "assets", "images", logo_filename) }
+      let(:logo_data) { "fake logo data" }
+
+      before do
+        ENV["PDF_LOGO"] = logo_filename
+        allow(File).to receive(:read).with(logo_path, mode: "rb").and_return(logo_data)
+      end
+
+      after do
+        ENV["PDF_LOGO"] = nil
+      end
+
+      it "returns logo data from the specified file" do
+        logo_width, data, attachment = described_class.send(:prepare_logo, user)
+
+        expect(logo_width).to eq(expected_logo_width)
+        expect(data).to eq(logo_data)
+        expect(attachment).to be_nil
+      end
+
+      it "ignores user logo even if attached" do
+        user.logo.attach(fixture_file_upload("test_image.jpg", "image/jpeg"))
+
+        logo_width, data, attachment = described_class.send(:prepare_logo, user)
+
+        expect(logo_width).to eq(expected_logo_width)
+        expect(data).to eq(logo_data)
+        expect(attachment).to be_nil
+      end
+
+      context "when the file does not exist" do
+        it "raises an error" do
+          allow(File).to receive(:read).with(logo_path, mode: "rb").and_raise(Errno::ENOENT)
+
+          expect {
+            described_class.send(:prepare_logo, user)
+          }.to raise_error(Errno::ENOENT)
+        end
+      end
+    end
+
+    context "when PDF_LOGO environment variable is not set" do
+      before do
+        ENV["PDF_LOGO"] = nil
+      end
+
+      context "when user is nil" do
+        it "returns empty values" do
+          logo_width, data, attachment = described_class.send(:prepare_logo, nil)
+
+          expect(logo_width).to eq(0)
+          expect(data).to be_nil
+          expect(attachment).to be_nil
+        end
+      end
+
+      context "when user has no logo attached" do
+        it "returns empty values" do
+          logo_width, data, attachment = described_class.send(:prepare_logo, user)
+
+          expect(logo_width).to eq(0)
+          expect(data).to be_nil
+          expect(attachment).to be_nil
+        end
+      end
+
+      context "when user has logo attached" do
+        let(:logo_content) { Rails.root.join("spec/fixtures/files/test_image.jpg").read(mode: "rb") }
+
+        before do
+          user.logo.attach(fixture_file_upload("test_image.jpg", "image/jpeg"))
+          user.logo.blob.analyze
+        end
+
+        it "returns logo data from user's attached logo" do
+          logo_width, data, attachment = described_class.send(:prepare_logo, user)
+
+          expect(logo_width).to eq(expected_logo_width)
+          expect(data).to eq(logo_content)
+          expect(attachment).to eq(user.logo)
+        end
+
+        it "downloads the logo data" do
+          expect(user.logo).to receive(:download).and_return(logo_content)
+
+          described_class.send(:prepare_logo, user)
+        end
+      end
+
+      context "when user logo attachment is broken" do
+        before do
+          user.logo.attach(fixture_file_upload("test_image.jpg", "image/jpeg"))
+          allow(user.logo).to receive(:download).and_raise(ActiveStorage::FileNotFoundError)
+        end
+
+        it "raises the error" do
+          expect {
+            described_class.send(:prepare_logo, user)
+          }.to raise_error(ActiveStorage::FileNotFoundError)
+        end
+      end
+    end
+
+    context "with empty PDF_LOGO value" do
+      before do
+        ENV["PDF_LOGO"] = ""
+      end
+
+      after do
+        ENV["PDF_LOGO"] = nil
+      end
+
+      it "treats empty string as not set" do
+        logo_width, data, attachment = described_class.send(:prepare_logo, user)
+
+        expect(logo_width).to eq(0)
+        expect(data).to be_nil
+        expect(attachment).to be_nil
+      end
+    end
+
+    context "logo dimensions calculation" do
+      context "when returning logo data" do
+        before do
+          user.logo.attach(fixture_file_upload("test_image.jpg", "image/jpeg"))
+        end
+
+        it "calculates consistent width based on height" do
+          logo_width, _, _ = described_class.send(:prepare_logo, user)
+
+          expect(logo_width).to eq(logo_height * 2 + 10)
+        end
+
+        it "uses the configured LOGO_HEIGHT constant" do
+          expect(PdfGeneratorService::Configuration::LOGO_HEIGHT).to be > 0
+
+          logo_width, _, _ = described_class.send(:prepare_logo, user)
+
+          expect(logo_width).to eq(PdfGeneratorService::Configuration::LOGO_HEIGHT * 2 + 10)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a new RSpec test suite for the `PdfGeneratorService::HeaderGenerator` class
- Covers the private `.prepare_logo` method extensively
- Tests behavior when `PDF_LOGO` environment variable is set, unset, or empty
- Validates handling of user logo attachments, including missing or broken attachments
- Ensures correct logo width calculation based on configured constants

## Changes

### Test Coverage
- Created `spec/services/pdf_generator_service/header_generator_spec.rb` with 155 lines of tests
- Mocked file reading and environment variables to simulate different logo sources
- Verified that environment variable logo takes precedence over user logo
- Tested error handling for missing logo files and broken ActiveStorage attachments
- Confirmed that empty or nil user returns empty logo data
- Checked that logo width calculation matches expected formula

## Test plan
- [x] Run the new RSpec tests to ensure all cases pass
- [x] Validate error raising for missing files and broken attachments
- [x] Confirm logo data is correctly returned from environment variable or user attachment
- [x] Verify logo width calculation consistency

This PR improves the reliability and robustness of the PDF header logo generation by ensuring all edge cases are tested and handled properly.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4bce113e-130d-4528-ae5e-ee1fe7832b73