### PR TITLE
Remove unused methods from assessment models

### DIFF
--- a/app/models/assessments/anchorage_assessment.rb
+++ b/app/models/assessments/anchorage_assessment.rb
@@ -62,15 +62,6 @@ class Assessments::AnchorageAssessment < ApplicationRecord
     (num_low_anchors || 0) + (num_high_anchors || 0)
   end
 
-  sig { returns(T.any(Object, NilClass)) }
-  def anchorage_result
-    @anchor_result ||= EN14960.calculate_anchors(
-      length: inspection.length.to_f,
-      width: inspection.width.to_f,
-      height: inspection.height.to_f
-    )
-  end
-
   sig { returns(Integer) }
   def required_anchors
     return 0 if inspection.volume.blank?
@@ -81,5 +72,16 @@ class Assessments::AnchorageAssessment < ApplicationRecord
   def anchorage_breakdown
     return [] unless inspection.volume
     anchorage_result.breakdown
+  end
+
+  private
+
+  sig { returns(T.any(Object, NilClass)) }
+  def anchorage_result
+    @anchor_result ||= EN14960.calculate_anchors(
+      length: inspection.length.to_f,
+      width: inspection.width.to_f,
+      height: inspection.height.to_f
+    )
   end
 end

--- a/app/models/assessments/materials_assessment.rb
+++ b/app/models/assessments/materials_assessment.rb
@@ -54,9 +54,4 @@ class Assessments::MaterialsAssessment < ApplicationRecord
   enum :artwork_pass, Inspection::PASS_FAIL_NA, prefix: true
 
   after_update :log_assessment_update, if: :saved_changes?
-
-  sig { returns(T::Boolean) }
-  def ropes_compliant?
-    EN14960.valid_rope_diameter?(ropes)
-  end
 end

--- a/app/models/assessments/slide_assessment.rb
+++ b/app/models/assessments/slide_assessment.rb
@@ -66,16 +66,6 @@ class Assessments::SlideAssessment < ApplicationRecord
     )
   end
 
-  sig { returns(String) }
-  def runout_compliance_status
-    return I18n.t("forms.slide.compliance.not_assessed") if runout.blank?
-    if meets_runout_requirements?
-      I18n.t("forms.slide.compliance.compliant")
-    else
-      I18n.t("forms.slide.compliance.non_compliant",
-        required: required_runout_length)
-    end
-  end
 
   sig { returns(T::Boolean) }
   def meets_wall_height_requirements?


### PR DESCRIPTION
## Summary
- Cleans up the codebase by removing unused methods from assessment models
- Moves `anchorage_result` method in `AnchorageAssessment` to private scope
- Removes unused `ropes_compliant?` method from `MaterialsAssessment`
- Removes unused `runout_compliance_status` method from `SlideAssessment`

## Changes

### AnchorageAssessment
- Moved `anchorage_result` method to private section to encapsulate it

### MaterialsAssessment
- Removed `ropes_compliant?` method as it is not used anywhere

### SlideAssessment
- Removed `runout_compliance_status` method which was unused

## Test plan
- Ensure all existing tests pass without modification
- Verify no references to removed methods remain in the codebase
- Run full test suite to confirm no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/40f75958-454a-4296-bc48-7d90e818d3be