### PR TITLE
Add Play Zone inspection type with assessment workflow

### DIFF
--- a/NEW_UNIT_TYPES.md
+++ b/NEW_UNIT_TYPES.md
@@ -8,11 +8,11 @@ Spencer's C# desktop app defines inspection checks for inflatable equipment type
 
 | Order | Unit Type | Unique Assessment | Shared Assessments | Conditionals | Status |
 |---|---|---|---|---|---|
-| 1 | `inflatable_ball_pool` | `ball_pool_assessment` (9 fields) | structure, materials, fan | none | |
-| 2 | `inflatable_game` | `inflatable_game_assessment` (9 fields) | structure, materials, fan | none | |
-| 3 | `catch_bed` | `catch_bed_assessment` (15 fields) | structure, materials, fan, anchorage | none | |
-| 4 | `bungee_run` | `bungee_assessment` (19 fields) | structure, materials, fan, anchorage | none | |
-| 5 | `play_zone` | `play_zone_assessment` (14 fields) | structure, materials, fan, user_height, slide | `has_slide` toggle | |
+| 1 | `inflatable_ball_pool` | `ball_pool_assessment` (9 fields) | structure, materials, fan | none | Done |
+| 2 | `inflatable_game` | `inflatable_game_assessment` (9 fields) | structure, materials, fan | none | Done |
+| 3 | `catch_bed` | `catch_bed_assessment` (15 fields) | structure, materials, fan, anchorage | none | Done |
+| 4 | `bungee_run` | `bungee_assessment` (19 fields) | structure, materials, fan, anchorage | none | Done |
+| 5 | `play_zone` | `play_zone_assessment` (14 fields) | structure, materials, fan, user_height, slide | `has_slide` toggle | Done |
 
 ## Per-Chunk Recipe
 

--- a/app/controllers/play_zone_assessments_controller.rb
+++ b/app/controllers/play_zone_assessments_controller.rb
@@ -1,0 +1,5 @@
+# typed: false
+
+class PlayZoneAssessmentsController < ApplicationController
+  include AssessmentController
+end

--- a/app/models/assessments/play_zone_assessment.rb
+++ b/app/models/assessments/play_zone_assessment.rb
@@ -1,0 +1,15 @@
+# typed: true
+# frozen_string_literal: true
+
+class Assessments::PlayZoneAssessment < ApplicationRecord
+  extend T::Sig
+  include AssessmentLogging
+  include AssessmentCompletion
+  include FormConfigurable
+  include ValidationConfigurable
+
+  self.primary_key = "inspection_id"
+  belongs_to :inspection
+
+  after_update :log_assessment_update, if: :saved_changes?
+end

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -59,7 +59,8 @@ class Inspection < ApplicationRecord
     catch_bed: "CATCH_BED",
     inflatable_ball_pool: "INFLATABLE_BALL_POOL",
     inflatable_game: "INFLATABLE_GAME",
-    pat_testable: "PAT_TESTABLE"
+    pat_testable: "PAT_TESTABLE",
+    play_zone: "PLAY_ZONE"
   }
 
   CASTLE_ASSESSMENT_TYPES = {
@@ -111,6 +112,15 @@ class Inspection < ApplicationRecord
     bungee_assessment: Assessments::BungeeAssessment
   }.freeze
 
+  PLAY_ZONE_ASSESSMENT_TYPES = {
+    structure_assessment: Assessments::StructureAssessment,
+    materials_assessment: Assessments::MaterialsAssessment,
+    fan_assessment: Assessments::FanAssessment,
+    user_height_assessment: Assessments::UserHeightAssessment,
+    slide_assessment: Assessments::SlideAssessment,
+    play_zone_assessment: Assessments::PlayZoneAssessment
+  }.freeze
+
   ALL_ASSESSMENT_TYPES =
     CASTLE_ASSESSMENT_TYPES
       .merge(PILLOW_ASSESSMENT_TYPES)
@@ -118,7 +128,8 @@ class Inspection < ApplicationRecord
       .merge(INFLATABLE_BALL_POOL_ASSESSMENT_TYPES)
       .merge(INFLATABLE_GAME_ASSESSMENT_TYPES)
       .merge(CATCH_BED_ASSESSMENT_TYPES)
-      .merge(BUNGEE_RUN_ASSESSMENT_TYPES).freeze
+      .merge(BUNGEE_RUN_ASSESSMENT_TYPES)
+      .merge(PLAY_ZONE_ASSESSMENT_TYPES).freeze
 
   USER_EDITABLE_PARAMS = %i[
     has_slide
@@ -153,7 +164,8 @@ class Inspection < ApplicationRecord
     bungee_run: %i[inspection_date] + DIMENSION_FIELDS,
     catch_bed: %i[inspection_date] + DIMENSION_FIELDS,
     inflatable_game: %i[inspection_date] + DIMENSION_FIELDS,
-    pat_testable: %i[inspection_date]
+    pat_testable: %i[inspection_date],
+    play_zone: %i[inspection_date has_slide] + DIMENSION_FIELDS
   }.freeze
 
   belongs_to :user
@@ -281,7 +293,8 @@ class Inspection < ApplicationRecord
     catch_bed: CATCH_BED_ASSESSMENT_TYPES,
     inflatable_ball_pool: INFLATABLE_BALL_POOL_ASSESSMENT_TYPES,
     inflatable_game: INFLATABLE_GAME_ASSESSMENT_TYPES,
-    pat_testable: PAT_TESTABLE_ASSESSMENT_TYPES
+    pat_testable: PAT_TESTABLE_ASSESSMENT_TYPES,
+    play_zone: PLAY_ZONE_ASSESSMENT_TYPES
   }.freeze
 
   sig { returns(T::Hash[Symbol, T.class_of(ApplicationRecord)]) }
@@ -296,6 +309,7 @@ class Inspection < ApplicationRecord
   sig { returns(T::Hash[Symbol, T.class_of(ApplicationRecord)]) }
   def applicable_assessments
     return castle_applicable_assessments if bouncy_castle?
+    return play_zone_applicable_assessments if play_zone?
 
     assessment_types
   end
@@ -314,6 +328,16 @@ class Inspection < ApplicationRecord
         !indoor_only?
       else
         true
+      end
+    end
+  end
+
+  sig { returns(T::Hash[Symbol, T.class_of(ApplicationRecord)]) }
+  def play_zone_applicable_assessments
+    PLAY_ZONE_ASSESSMENT_TYPES.select do |assessment_key, _|
+      case assessment_key
+      when :slide_assessment then has_slide?
+      else true
       end
     end
   end
@@ -344,7 +368,7 @@ class Inspection < ApplicationRecord
     applicable = applicable_assessments.keys.map { |k| k.to_s.chomp("_assessment") }
 
     # Add tabs in the correct UI order
-    ordered_tabs = %w[user_height slide structure anchorage materials fan enclosed pat ball_pool bungee catch_bed inflatable_game]
+    ordered_tabs = %w[user_height slide structure anchorage materials fan enclosed pat ball_pool bungee catch_bed inflatable_game play_zone]
     ordered_tabs.each do |tab|
       tabs << tab if applicable.include?(tab)
     end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -46,7 +46,8 @@ class Unit < ApplicationRecord
     catch_bed: "CATCH_BED",
     inflatable_ball_pool: "INFLATABLE_BALL_POOL",
     inflatable_game: "INFLATABLE_GAME",
-    pat_testable: "PAT_TESTABLE"
+    pat_testable: "PAT_TESTABLE",
+    play_zone: "PLAY_ZONE"
   }
 
   belongs_to :user

--- a/config/forms/play_zone_assessment.yml
+++ b/config/forms/play_zone_assessment.yml
@@ -1,0 +1,48 @@
+---
+form_fields:
+  - legend_i18n_key: markings
+    fields:
+      - partial: :pass_fail_comment
+        field: :age_marking
+      - partial: :pass_fail_comment
+        field: :height_marking
+  - legend_i18n_key: safety_checks
+    fields:
+      - partial: :pass_fail_comment
+        field: :sight_line
+      - partial: :pass_fail_comment
+        field: :access
+      - partial: :pass_fail_comment
+        field: :suitable_matting
+      - partial: :pass_fail_comment
+        field: :traffic_flow
+      - partial: :pass_fail_comment
+        field: :air_juggler
+      - partial: :pass_fail_comment
+        field: :balls
+      - partial: :pass_fail_comment
+        field: :ball_pool_gaps
+      - partial: :pass_fail_comment
+        field: :fitted_sheet
+  - legend_i18n_key: measurements
+    fields:
+      - partial: :number_pass_fail_comment
+        field: :ball_pool_depth
+        attributes:
+          step: 1
+          min: 0
+      - partial: :number_pass_fail_comment
+        field: :ball_pool_entry_height
+        attributes:
+          step: 1
+          min: 0
+      - partial: :number_pass_fail_comment
+        field: :slide_gradient
+        attributes:
+          step: 1
+          min: 0
+      - partial: :number_pass_fail_comment
+        field: :slide_platform_height
+        attributes:
+          step: 0.01
+          min: 0

--- a/config/locales/forms/play_zone.en.yml
+++ b/config/locales/forms/play_zone.en.yml
@@ -1,0 +1,33 @@
+---
+en:
+  forms:
+    play_zone:
+      header: Play Zone
+      sections:
+        markings: Markings
+        safety_checks: Safety Checks
+        measurements: Measurements
+      fields:
+        age_marking: Marking to indicate age range
+        height_marking: Marking to indicate max user height
+        sight_line: Sight lines clear to observe playing areas
+        access: Access, egress and connections safe
+        suitable_matting: Suitable matting
+        traffic_flow: Traffic flow design safe
+        air_juggler: Air jugglers compliant
+        balls: Balls compliant
+        ball_pool_gaps: No gaps in ball pool
+        fitted_sheet: Fitted base sheet
+        ball_pool_depth: Ball pool depth (mm) max 450mm
+        ball_pool_entry_height: Ball pool entry height (mm) max 630mm
+        slide_gradient: Platform incline gradient (deg) max 64 deg
+        slide_platform_height: Slide platform height (m) max 1.5m
+      status:
+        checks_passed: Fields completed
+        completion: Assessment Completion
+      submit: Save Assessment
+      submit_continue: Save & Continue
+      errors:
+        header:
+          one: '1 error prevented this assessment from being saved:'
+          other: '%{count} errors prevented this assessment from being saved:'

--- a/config/locales/inspections.en.yml
+++ b/config/locales/inspections.en.yml
@@ -271,6 +271,7 @@ en:
       inflatable_game_incomplete: Inflatable Game Assessment incomplete
       materials_incomplete: Materials Assessment incomplete
       pat_incomplete: PAT Assessment incomplete
+      play_zone_incomplete: Play Zone Assessment incomplete
       slide_incomplete: Slide Assessment incomplete
       structure_incomplete: Structure Assessment incomplete
       user_height_incomplete: User Height Assessment incomplete

--- a/config/locales/units.en.yml
+++ b/config/locales/units.en.yml
@@ -71,6 +71,7 @@ en:
       inflatable_ball_pool: Inflatable Ball Pool
       inflatable_game: Inflatable Game
       pat_testable: PAT Testable Appliance
+      play_zone: Play Zone
     labels:
       inspection_date: Inspection Date
       dimensions: Dimensions

--- a/db/migrate/20260325000003_create_play_zone_assessments.rb
+++ b/db/migrate/20260325000003_create_play_zone_assessments.rb
@@ -1,0 +1,57 @@
+# typed: false
+# frozen_string_literal: true
+
+class CreatePlayZoneAssessments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :play_zone_assessments, id: false do |t|
+      t.string :inspection_id, limit: 12, null: false
+      add_pass_fail_fields(t)
+      add_measurement_fields(t)
+      t.timestamps
+    end
+
+    add_index :play_zone_assessments, :inspection_id,
+      unique: true, name: "play_zone_assessments_pkey"
+    add_foreign_key :play_zone_assessments, :inspections
+  end
+
+  private
+
+  def add_pass_fail_fields(t)
+    t.boolean :age_marking_pass
+    t.text :age_marking_comment
+    t.boolean :height_marking_pass
+    t.text :height_marking_comment
+    t.boolean :sight_line_pass
+    t.text :sight_line_comment
+    t.boolean :access_pass
+    t.text :access_comment
+    t.boolean :suitable_matting_pass
+    t.text :suitable_matting_comment
+    t.boolean :traffic_flow_pass
+    t.text :traffic_flow_comment
+    t.boolean :air_juggler_pass
+    t.text :air_juggler_comment
+    t.boolean :balls_pass
+    t.text :balls_comment
+    t.boolean :ball_pool_gaps_pass
+    t.text :ball_pool_gaps_comment
+    t.boolean :fitted_sheet_pass
+    t.text :fitted_sheet_comment
+  end
+
+  def add_measurement_fields(t)
+    t.integer :ball_pool_depth
+    t.boolean :ball_pool_depth_pass
+    t.text :ball_pool_depth_comment
+    t.integer :ball_pool_entry_height
+    t.boolean :ball_pool_entry_height_pass
+    t.text :ball_pool_entry_height_comment
+    t.integer :slide_gradient
+    t.boolean :slide_gradient_pass
+    t.text :slide_gradient_comment
+    t.decimal :slide_platform_height, precision: 8, scale: 2
+    t.boolean :slide_platform_height_pass
+    t.text :slide_platform_height_comment
+  end
+end

--- a/lib/seed_data.rb
+++ b/lib/seed_data.rb
@@ -406,6 +406,59 @@ module SeedData
     }
   end
 
+  def self.play_zone_fields(passed: true)
+    play_zone_pass_fields(passed)
+      .merge(play_zone_measurements(passed))
+      .merge(play_zone_comments(passed))
+  end
+
+  def self.play_zone_pass_fields(passed)
+    {
+      age_marking_pass: check_passed?(passed),
+      height_marking_pass: check_passed?(passed),
+      sight_line_pass: check_passed?(passed),
+      access_pass: check_passed?(passed),
+      suitable_matting_pass: check_passed?(passed),
+      traffic_flow_pass: check_passed?(passed),
+      air_juggler_pass: check_passed?(passed),
+      balls_pass: check_passed?(passed),
+      ball_pool_gaps_pass: check_passed?(passed),
+      fitted_sheet_pass: check_passed?(passed)
+    }
+  end
+
+  def self.play_zone_measurements(passed)
+    {
+      ball_pool_depth: rand(300..450),
+      ball_pool_depth_pass: check_passed?(passed),
+      ball_pool_entry_height: rand(500..630),
+      ball_pool_entry_height_pass: check_passed?(passed),
+      slide_gradient: rand(40..64),
+      slide_gradient_pass: check_passed?(passed),
+      slide_platform_height: rand(1.0..1.5).round(2),
+      slide_platform_height_pass: check_passed?(passed)
+    }
+  end
+
+  def self.play_zone_comments(passed)
+    {
+      age_marking_comment: passed ? OK : FAIL,
+      height_marking_comment: passed ? OK : FAIL,
+      sight_line_comment: passed ? OK : FAIL,
+      access_comment: passed ? OK : FAIL,
+      suitable_matting_comment: passed ? GOOD : FAIL,
+      traffic_flow_comment: passed ? OK : FAIL,
+      air_juggler_comment: passed ? PASS : FAIL,
+      balls_comment: passed ? PASS : FAIL,
+      ball_pool_gaps_comment: passed ? OK : FAIL,
+      fitted_sheet_comment: passed ? OK : FAIL,
+      ball_pool_depth_comment: passed ? OK : FAIL,
+      ball_pool_entry_height_comment: passed ? OK : FAIL,
+      slide_gradient_comment: passed ? OK : FAIL,
+      slide_platform_height_comment: passed ? OK : FAIL
+    }
+  end
+
   def self.pat_fields(passed: true)
     pat_numeric_fields
       .merge(pat_pass_fields(passed))

--- a/spec/factories/play_zone_assessments.rb
+++ b/spec/factories/play_zone_assessments.rb
@@ -1,0 +1,106 @@
+# typed: false
+
+FactoryBot.define do
+  factory :play_zone_assessment, class: "Assessments::PlayZoneAssessment" do
+    association :inspection
+
+    # Pass/fail assessments
+    age_marking_pass { nil }
+    height_marking_pass { nil }
+    sight_line_pass { nil }
+    access_pass { nil }
+    suitable_matting_pass { nil }
+    traffic_flow_pass { nil }
+    air_juggler_pass { nil }
+    balls_pass { nil }
+    ball_pool_gaps_pass { nil }
+    fitted_sheet_pass { nil }
+    ball_pool_depth_pass { nil }
+    ball_pool_entry_height_pass { nil }
+    slide_gradient_pass { nil }
+    slide_platform_height_pass { nil }
+
+    # Measurements
+    ball_pool_depth { nil }
+    ball_pool_entry_height { nil }
+    slide_gradient { nil }
+    slide_platform_height { nil }
+
+    trait :passed do
+      age_marking_pass { true }
+      height_marking_pass { true }
+      sight_line_pass { true }
+      access_pass { true }
+      suitable_matting_pass { true }
+      traffic_flow_pass { true }
+      air_juggler_pass { true }
+      balls_pass { true }
+      ball_pool_gaps_pass { true }
+      fitted_sheet_pass { true }
+      ball_pool_depth { 400 }
+      ball_pool_depth_pass { true }
+      ball_pool_entry_height { 600 }
+      ball_pool_entry_height_pass { true }
+      slide_gradient { 50 }
+      slide_gradient_pass { true }
+      slide_platform_height { 1.2 }
+      slide_platform_height_pass { true }
+    end
+
+    trait :complete do
+      age_marking_pass { true }
+      age_marking_comment { SeedData::OK }
+      height_marking_pass { true }
+      height_marking_comment { SeedData::OK }
+      sight_line_pass { true }
+      sight_line_comment { SeedData::OK }
+      access_pass { true }
+      access_comment { SeedData::OK }
+      suitable_matting_pass { true }
+      suitable_matting_comment { SeedData::OK }
+      traffic_flow_pass { true }
+      traffic_flow_comment { SeedData::OK }
+      air_juggler_pass { true }
+      air_juggler_comment { SeedData::PASS }
+      balls_pass { true }
+      balls_comment { SeedData::PASS }
+      ball_pool_gaps_pass { true }
+      ball_pool_gaps_comment { SeedData::OK }
+      fitted_sheet_pass { true }
+      fitted_sheet_comment { SeedData::OK }
+      ball_pool_depth { 400 }
+      ball_pool_depth_pass { true }
+      ball_pool_depth_comment { SeedData::OK }
+      ball_pool_entry_height { 600 }
+      ball_pool_entry_height_pass { true }
+      ball_pool_entry_height_comment { SeedData::OK }
+      slide_gradient { 50 }
+      slide_gradient_pass { true }
+      slide_gradient_comment { SeedData::OK }
+      slide_platform_height { 1.2 }
+      slide_platform_height_pass { true }
+      slide_platform_height_comment { SeedData::OK }
+    end
+
+    trait :failed do
+      age_marking_pass { false }
+      height_marking_pass { false }
+      sight_line_pass { true }
+      access_pass { true }
+      suitable_matting_pass { true }
+      traffic_flow_pass { false }
+      air_juggler_pass { true }
+      balls_pass { false }
+      ball_pool_gaps_pass { false }
+      fitted_sheet_pass { true }
+      ball_pool_depth { 500 }
+      ball_pool_depth_pass { false }
+      ball_pool_entry_height { 700 }
+      ball_pool_entry_height_pass { false }
+      slide_gradient { 70 }
+      slide_gradient_pass { false }
+      slide_platform_height { 2.0 }
+      slide_platform_height_pass { false }
+    end
+  end
+end

--- a/spec/features/inspections/play_zone_workflow_spec.rb
+++ b/spec/features/inspections/play_zone_workflow_spec.rb
@@ -1,0 +1,206 @@
+# typed: false
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Play Zone Inspection Workflow", type: :feature do
+  include InspectionTestHelpers
+
+  let(:user) { create(:user) }
+
+  before { sign_in(user) }
+
+  scenario "complete play zone inspection workflow with slide" do
+    unit = create_play_zone_unit
+    inspection = create_inspection_for_unit(unit)
+
+    verify_correct_tabs_visible(inspection, with_slide: false)
+    fill_inspection_tab(inspection, has_slide: true)
+
+    # After setting has_slide, slide tab should appear
+    verify_correct_tabs_visible(inspection, with_slide: true)
+    fill_all_play_zone_assessments(inspection, with_slide: true)
+    complete_inspection(inspection)
+    verify_inspection_complete(inspection)
+  end
+
+  scenario "complete play zone inspection workflow without slide" do
+    unit = create_play_zone_unit
+    inspection = create_inspection_for_unit(unit)
+
+    fill_inspection_tab(inspection, has_slide: false)
+    verify_correct_tabs_visible(inspection, with_slide: false)
+    fill_all_play_zone_assessments(inspection, with_slide: false)
+    complete_inspection(inspection)
+    verify_inspection_complete(inspection)
+  end
+
+  scenario "play zone unit shows correct unit type" do
+    visit units_path
+    click_button I18n.t("units.buttons.add_unit")
+
+    unit_data = SeedData.unit_fields.merge(name: "Test Play Zone")
+    unit_data.each do |field_name, value|
+      fill_in_form :units, field_name, value
+    end
+
+    select I18n.t("units.unit_types.play_zone"),
+      from: I18n.t("forms.units.fields.unit_type")
+
+    submit_form :units
+    expect_units_message("created")
+
+    unit = Unit.find_by!(name: "Test Play Zone")
+    expect(unit.unit_type).to eq("play_zone")
+  end
+
+  scenario "play zone inspection shows correct tabs" do
+    unit = create(:unit, user: user, unit_type: :play_zone)
+    inspection = create(:inspection, user: user, unit: unit)
+
+    visit edit_inspection_path(inspection)
+
+    expect_assessment_tab("structure")
+    expect_assessment_tab("user_height")
+    expect_assessment_tab("materials")
+    expect_assessment_tab("fan")
+    expect_assessment_tab("play_zone")
+
+    # Slide tab not shown until has_slide is set
+    expect_no_assessment_tab("slide")
+
+    %w[enclosed pat ball_pool catch_bed
+      inflatable_game anchorage bungee].each do |tab|
+      expect_no_assessment_tab(tab)
+    end
+  end
+
+  scenario "play zone form renders all i18n fields" do
+    unit = create(:unit, user: user, unit_type: :play_zone)
+    inspection = create(:inspection, user: user, unit: unit)
+
+    visit edit_inspection_path(inspection, tab: "play_zone")
+
+    expect_form_matches_i18n("forms.play_zone")
+  end
+
+  private
+
+  def create_play_zone_unit
+    visit units_path
+    click_button I18n.t("units.buttons.add_unit")
+
+    unit_data = SeedData.unit_fields
+      .merge(name: "Play Zone Unit")
+    unit_data.each do |field_name, value|
+      fill_in_form :units, field_name, value
+    end
+
+    select I18n.t("units.unit_types.play_zone"),
+      from: I18n.t("forms.units.fields.unit_type")
+
+    submit_form :units
+    expect_units_message("created")
+
+    Unit.find_by!(name: "Play Zone Unit")
+  end
+
+  def create_inspection_for_unit(unit)
+    inspection = create(:inspection, user: user, unit: unit)
+    expect(inspection.inspection_type).to eq("play_zone")
+    inspection
+  end
+
+  def verify_correct_tabs_visible(inspection, with_slide:)
+    visit edit_inspection_path(inspection)
+
+    expect_assessment_tab("structure")
+    expect_assessment_tab("user_height")
+    expect_assessment_tab("materials")
+    expect_assessment_tab("fan")
+    expect_assessment_tab("play_zone")
+
+    if with_slide
+      expect_assessment_tab("slide")
+    else
+      expect_no_assessment_tab("slide")
+    end
+
+    %w[enclosed pat ball_pool catch_bed
+      inflatable_game anchorage bungee].each do |tab|
+      expect_no_assessment_tab(tab)
+    end
+  end
+
+  def fill_inspection_tab(inspection, has_slide:)
+    visit edit_inspection_path(inspection)
+
+    field_data = SeedData.inspection_fields(passed: true)
+    field_data.except!(:is_totally_enclosed, :indoor_only)
+    field_data[:has_slide] = has_slide
+
+    field_data.each do |field_name, value|
+      fill_inspection_field(field_name, value)
+    end
+
+    click_submit_button
+  end
+
+  def fill_all_play_zone_assessments(inspection, with_slide:)
+    tabs = {
+      "structure" => SeedData.structure_fields(passed: true),
+      "user_height" =>
+        SeedData.user_height_fields(passed: true),
+      "materials" => SeedData.materials_fields(passed: true),
+      "fan" => SeedData.fan_fields(passed: true),
+      "play_zone" =>
+        SeedData.play_zone_fields(passed: true)
+    }
+
+    if with_slide
+      tabs["slide"] = SeedData.slide_fields(passed: true)
+    end
+
+    tabs.each do |tab, fields|
+      fill_assessment(inspection, tab, fields)
+    end
+
+    fill_results_tab(inspection)
+  end
+
+  def fill_results_tab(inspection)
+    visit edit_inspection_path(inspection, tab: "results")
+    fill_assessment_field("results", :passed, true)
+    fill_in_risk_assessment(
+      "Unit passes all play zone checks"
+    )
+    submit_form :results
+    expect_updated_message
+  end
+
+  def fill_assessment(inspection, tab_name, field_data)
+    visit edit_inspection_path(inspection, tab: tab_name)
+
+    field_data.each do |field_name, value|
+      fill_assessment_field(tab_name, field_name, value)
+    end
+
+    submit_form tab_name.to_sym
+    expect_updated_message
+  end
+
+  def complete_inspection(inspection)
+    visit edit_inspection_path(inspection)
+    expect(page).to have_button(
+      I18n.t("inspections.buttons.mark_complete")
+    )
+    click_mark_complete_button
+    expect_marked_complete_message
+  end
+
+  def verify_inspection_complete(inspection)
+    inspection.reload
+    expect(inspection.complete?).to be true
+    expect(inspection.complete_date).to be_present
+  end
+end

--- a/spec/features/inspections/play_zone_workflow_spec.rb
+++ b/spec/features/inspections/play_zone_workflow_spec.rb
@@ -56,7 +56,10 @@ RSpec.feature "Play Zone Inspection Workflow", type: :feature do
 
   scenario "play zone inspection shows correct tabs" do
     unit = create(:unit, user: user, unit_type: :play_zone)
-    inspection = create(:inspection, user: user, unit: unit)
+    inspection = create(
+      :inspection, user: user, unit: unit,
+      has_slide: nil
+    )
 
     visit edit_inspection_path(inspection)
 
@@ -106,7 +109,10 @@ RSpec.feature "Play Zone Inspection Workflow", type: :feature do
   end
 
   def create_inspection_for_unit(unit)
-    inspection = create(:inspection, user: user, unit: unit)
+    inspection = create(
+      :inspection, user: user, unit: unit,
+      has_slide: nil
+    )
     expect(inspection.inspection_type).to eq("play_zone")
     inspection
   end


### PR DESCRIPTION
## Summary
This PR adds support for Play Zone as a new inspection unit type with a complete assessment workflow. Play Zones are inflatable entertainment structures that require specialized inspection checks for safety markings, structural integrity, and equipment compliance.

## Key Changes

### New Models & Database
- Created `Assessments::PlayZoneAssessment` model to store play zone-specific inspection data
- Added database migration creating `play_zone_assessments` table with 14 pass/fail checks and 4 measurement fields
- Defined assessment fields for markings (age/height), safety checks (sight lines, access, matting, traffic flow, air jugglers, balls, ball pool gaps, fitted sheets), and measurements (ball pool depth/entry height, slide gradient/platform height)

### Inspection Configuration
- Added `play_zone` inspection type to `Inspection` model with enum value `PLAY_ZONE`
- Configured play zone inspection to include shared assessments: structure, materials, fan, user_height, and conditionally slide (when `has_slide` is true)
- Added `PLAY_ZONE_ASSESSMENT_TYPES` mapping and integrated into `ALL_ASSESSMENT_TYPES`
- Implemented `play_zone_applicable_assessments` method to conditionally include slide assessment based on `has_slide` flag

### Unit Type Support
- Added `play_zone` unit type to `Unit` model
- Added i18n translations for play zone unit type in units locale

### Forms & Validation
- Created `config/forms/play_zone_assessment.yml` defining form structure with three sections: markings, safety checks, and measurements
- Added comprehensive i18n translations in `config/locales/forms/play_zone.en.yml` with field labels and validation messages
- Created `PlayZoneAssessmentsController` using standard assessment controller pattern

### Test Support
- Added `play_zone_assessment` factory with `:passed`, `:complete`, and `:failed` traits
- Extended `SeedData` with `play_zone_fields`, `play_zone_pass_fields`, `play_zone_measurements`, and `play_zone_comments` methods
- Created comprehensive feature spec `play_zone_workflow_spec.rb` covering:
  - Complete workflow with and without slide
  - Unit type creation and verification
  - Tab visibility and conditional rendering
  - Form field i18n validation

### Documentation
- Updated `NEW_UNIT_TYPES.md` to mark play zone as complete

## Notable Implementation Details
- Play zone inspections use conditional assessment loading: the slide assessment only appears when `has_slide` is set to true
- Measurement fields use appropriate data types (integers for mm, decimal for meters)
- Assessment follows existing patterns for shared assessments (structure, materials, fan, user_height) with play zone-specific checks
- Form configuration uses existing partials (`pass_fail_comment`, `number_pass_fail_comment`) for consistency

https://claude.ai/code/session_016Af3G5HbcoYzxLaQC4tDKp