### PR TITLE
Strengthen Event and InspectorCompany specs (mutation-driven)

### DIFF
--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -57,7 +57,97 @@ RSpec.describe Event, type: :model do
     end
   end
 
+  describe ".log" do
+    it "creates an event mapping every attribute from the resource" do
+      event = Event.log(
+        user: user,
+        action: "updated",
+        resource: unit,
+        details: "Changed the name",
+        changed_data: {"name" => "New"},
+        metadata: {"ip" => "127.0.0.1"}
+      )
+
+      expect(event).to be_persisted
+      expect(event.user).to eq(user)
+      expect(event.action).to eq("updated")
+      expect(event.resource_type).to eq("Unit")
+      expect(event.resource_id).to eq(unit.id)
+      expect(event.details).to eq("Changed the name")
+      expect(event.changed_data).to eq({"name" => "New"})
+      expect(event.metadata).to eq({"ip" => "127.0.0.1"})
+    end
+
+    it "defaults details, changed_data and metadata to nil" do
+      event = Event.log(user: user, action: "viewed", resource: unit)
+
+      expect(event.details).to be_nil
+      expect(event.changed_data).to be_nil
+      expect(event.metadata).to be_nil
+    end
+  end
+
+  describe ".log_system_event" do
+    it "creates an event with the system resource type and no resource id" do
+      event = Event.log_system_event(
+        user: user,
+        action: "backup_completed",
+        details: "Daily backup completed",
+        metadata: {"size" => "1GB"}
+      )
+
+      expect(event).to be_persisted
+      expect(event.user).to eq(user)
+      expect(event.action).to eq("backup_completed")
+      expect(event.resource_type).to eq(Event.system_resource_type)
+      expect(event.resource_id).to be_nil
+      expect(event.details).to eq("Daily backup completed")
+      expect(event.metadata).to eq({"size" => "1GB"})
+    end
+  end
+
+  describe "#description" do
+    it "returns the details when present" do
+      event = Event.log(
+        user: user,
+        action: "updated",
+        resource: unit,
+        details: "A human readable summary"
+      )
+
+      expect(event.description).to eq("A human readable summary")
+    end
+
+    it "falls back to a summary built from the event fields" do
+      event = Event.log(user: user, action: "updated", resource: unit)
+      expected = "#{user.email} updated Unit #{unit.id}"
+
+      expect(event.description).to eq(expected)
+    end
+  end
+
+  describe "#triggered_by?" do
+    it "is true for the user who triggered the event" do
+      event = Event.log(user: user, action: "viewed", resource: unit)
+
+      expect(event.triggered_by?(user)).to be true
+    end
+
+    it "is false for a different user" do
+      other_user = create(:user)
+      event = Event.log(user: user, action: "viewed", resource: unit)
+
+      expect(event.triggered_by?(other_user)).to be false
+    end
+  end
+
   describe "#resource_object" do
+    it "returns the resource when it still exists" do
+      event = Event.log(user: user, action: "viewed", resource: unit)
+
+      expect(event.resource_object).to eq(unit)
+    end
+
     it "returns nil when resource has been deleted" do
       event = Event.create!(
         user: user,

--- a/spec/models/inspector_company_spec.rb
+++ b/spec/models/inspector_company_spec.rb
@@ -125,6 +125,18 @@ RSpec.describe InspectorCompany, type: :model do
       it "returns 0 when no inspections" do
         expect(company.pass_rate).to eq(0)
       end
+
+      it "rounds the percentage to two decimal places" do
+        expect(company.pass_rate(3, 1)).to eq(33.33)
+      end
+
+      it "computes the rate from the company inspections" do
+        user = create(:user, inspection_company: company)
+        create(:inspection, :passed, user: user)
+        create_list(:inspection, 3, :failed, user: user)
+
+        expect(company.pass_rate).to eq(25.0)
+      end
     end
 
     describe "#company_statistics" do
@@ -138,11 +150,75 @@ RSpec.describe InspectorCompany, type: :model do
           :active_since
         )
       end
+
+      it "counts passed and failed inspections" do
+        user = create(:user, inspection_company: company)
+        create_list(:inspection, 2, :passed, user: user)
+        create(:inspection, :failed, user: user)
+
+        stats = company.company_statistics
+
+        expect(stats[:total_inspections]).to eq(3)
+        expect(stats[:passed_inspections]).to eq(2)
+        expect(stats[:failed_inspections]).to eq(1)
+        expect(stats[:pass_rate]).to eq(66.67)
+        expect(stats[:active_since]).to eq(company.created_at.year)
+      end
+
+      it "reports zero counts when there are no inspections of a status" do
+        user = create(:user, inspection_company: company)
+        create(:inspection, :passed, user: user)
+
+        stats = company.company_statistics
+
+        expect(stats[:passed_inspections]).to eq(1)
+        expect(stats[:failed_inspections]).to eq(0)
+      end
+    end
+
+    describe "#recent_inspections" do
+      it "returns inspections most recent first, limited" do
+        user = create(:user, inspection_company: company)
+        old = create(:inspection, user: user, inspection_date: 3.days.ago)
+        mid = create(:inspection, user: user, inspection_date: 2.days.ago)
+        recent = create(:inspection, user: user, inspection_date: 1.day.ago)
+
+        expect(company.recent_inspections(2)).to eq([recent, mid])
+        expect(company.recent_inspections(2)).not_to include(old)
+      end
+
+      it "defaults to returning up to ten inspections" do
+        user = create(:user, inspection_company: company)
+        create(:inspection, user: user)
+
+        expect(company.recent_inspections.count).to eq(1)
+      end
+    end
+
+    describe ".form_schema" do
+      it "includes the notes field for admins" do
+        admin = create(:user, :admin)
+        schema = InspectorCompany.form_schema(user: admin)
+
+        expect(schema.find_field(:notes)).to be_present
+      end
+
+      it "excludes the notes field for non-admins" do
+        schema = InspectorCompany.form_schema(user: create(:user))
+
+        expect(schema.find_field(:notes)).to be_nil
+      end
     end
 
     describe "#logo_url" do
       it "returns nil when no logo attached" do
         expect(company.logo_url).to be_nil
+      end
+
+      it "returns the logo when one is attached" do
+        company.logo.attach(fixture_file_upload("test_image.jpg", "image/jpeg"))
+
+        expect(company.logo_url).to eq(company.logo)
       end
     end
   end


### PR DESCRIPTION
## Summary

Follow-up to #506 (which added the [mutant](https://github.com/mbj/mutant) mutation-testing engine). That run surfaced real gaps in two core models — behaviour that no test asserted on, so mutating the source didn't fail anything. This PR adds tests that close those gaps.

## Changes

**`spec/models/event_spec.rb`**
- `.log` — asserts every attribute (`user`, `action`, `resource_type` from `resource.class.name`, `resource_id`, `details`, `changed_data`, `metadata`) is mapped onto the created record, plus the nil defaults.
- `.log_system_event` — asserts the system resource type and nil resource id.
- `#description` — asserts `details` is used when present, and the generated fallback (`"<email> <action> <type> <id>"`) otherwise.
- `#triggered_by?` — true for the triggering user, false for another.
- `#resource_object` — adds the positive case (returns the resource when it still exists).

**`spec/models/inspector_company_spec.rb`**
- `#pass_rate` — asserts an actual computed, two-decimal-rounded percentage (previously only the zero-inspection case was tested).
- `#company_statistics` — asserts the passed/failed/total counts and `active_since`, including the zero-of-a-status case.
- `#recent_inspections` — asserts most-recent-first ordering, the limit, and the default argument.
- `.form_schema` — asserts the `notes` field is included for admins and excluded for non-admins.
- `#logo_url` — asserts it returns the logo when one is attached.

## Mutation coverage impact

| Subject | Before | After |
|---|---|---|
| `Event` | 66.94% | **95.87%** |
| `InspectorCompany` | 89.60% | **96.80%** |

Remaining survivors are equivalent mutants (e.g. `send`↔`public_send`, redundant guards masked by `rescue`, `return`↔`nil` on a presence-validated field) — semantically identical code that no test can distinguish, so they're left as-is rather than chased with contrived assertions.

Only test files change; no production code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLseCgvqE2jdan8K57ENJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLseCgvqE2jdan8K57ENJn)_